### PR TITLE
Short-circuit git source updates for unchanged remote commits

### DIFF
--- a/apps/cli/src/cli.tsx
+++ b/apps/cli/src/cli.tsx
@@ -284,8 +284,9 @@ program
     for (const item of result.data.updated) {
       const summary = summaries.find((summary) => summary.source.id === item.sourceId);
       const groupRef = summary ? formatGroupRef(summary.source) : item.sourceId;
+      const repair = item.repaired ? `  repaired:${item.repairReason}` : "";
       console.log(
-        `${groupRef}  changed:${item.changed}  +${item.addedLeafIds.length}  -${item.removedLeafIds.length}  invalidated:${item.invalidatedLeafIds.length}`,
+        `${groupRef}  changed:${item.changed}${repair}  +${item.addedLeafIds.length}  -${item.removedLeafIds.length}  invalidated:${item.invalidatedLeafIds.length}`,
       );
     }
     printWarnings(result.warnings.map((warning) => warning.message));

--- a/apps/desktop-mac/Sources/DesktopApp/ViewModels/MainViewModel.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/ViewModels/MainViewModel.swift
@@ -1210,7 +1210,7 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
             let response = try await sourceManagement.updateSelectedSource(sourceId)
             await synchronizeState(refreshDoctor: true)
             registerRecentlyUpdatedSources(from: response?.data?.value)
-            showToast(style: .success, text: .plain(updateSummaryMessage(from: nil, fallbackCount: 1)))
+            showToast(style: .success, text: .plain(updateSummaryMessage(from: response?.data?.value, fallbackCount: 1)))
         } catch {
             showOperationFailureToast(fallbackKey: "toast.update.failed", fallbackArgument: error.localizedDescription, error: error)
         }
@@ -1884,6 +1884,12 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
     }
 
     private func updateSummaryMessage(from value: Any?, fallbackCount: Int) -> String {
+        if let payload = value as? [String: Any],
+           let items = payload["updated"] as? [[String: Any]],
+           let repaired = items.first(where: { $0["repaired"] as? Bool == true }) {
+            let reason = (repaired["repairReason"] as? String) ?? "local drift"
+            return "Recovered local checkout (\(reason))"
+        }
         fallbackCount == 1 ? localized("toast.update.summary.single") : localized("toast.update.summary.multiple", String(fallbackCount))
     }
 
@@ -1897,6 +1903,7 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
 
         for item in items {
             let changed = item["changed"] as? Bool == true
+                || item["repaired"] as? Bool == true
                 || ((item["addedLeafIds"] as? [String])?.isEmpty == false)
                 || ((item["removedLeafIds"] as? [String])?.isEmpty == false)
                 || ((item["invalidatedLeafIds"] as? [String])?.isEmpty == false)

--- a/apps/desktop-mac/Sources/DesktopApp/ViewModels/SourceManagement.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/ViewModels/SourceManagement.swift
@@ -779,6 +779,7 @@ final class SourceManagement {
                 let sourceId = (item["sourceId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
                 !sourceId.isEmpty,
                 item["changed"] as? Bool == true ||
+                item["repaired"] as? Bool == true ||
                 ((item["addedLeafIds"] as? [String])?.isEmpty == false) ||
                 ((item["removedLeafIds"] as? [String])?.isEmpty == false) ||
                 ((item["invalidatedLeafIds"] as? [String])?.isEmpty == false),

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -120,7 +119,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -138,7 +136,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -156,7 +153,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -174,7 +170,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -192,7 +187,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -210,7 +204,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -228,7 +221,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -246,7 +238,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -264,7 +255,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -282,7 +272,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -300,7 +289,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -318,7 +306,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -336,7 +323,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -354,7 +340,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -372,7 +357,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -390,7 +374,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -408,7 +391,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -426,7 +408,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -444,7 +425,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -462,7 +442,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -480,7 +459,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -498,7 +476,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -516,7 +493,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -534,7 +510,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -552,7 +527,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -119,6 +120,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -136,6 +138,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -153,6 +156,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -170,6 +174,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -187,6 +192,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -204,6 +210,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -221,6 +228,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -238,6 +246,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -255,6 +264,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -272,6 +282,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -289,6 +300,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -306,6 +318,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -323,6 +336,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -340,6 +354,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -357,6 +372,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -374,6 +390,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -391,6 +408,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -408,6 +426,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -425,6 +444,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -442,6 +462,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -459,6 +480,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -476,6 +498,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -493,6 +516,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -510,6 +534,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -527,6 +552,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/packages/core-engine/src/services/deployment-planner.ts
+++ b/packages/core-engine/src/services/deployment-planner.ts
@@ -436,8 +436,8 @@ export class DeploymentPlanner {
   ): Promise<boolean> {
     try {
       const [targetHash, sourceHash] = await Promise.all([
-        hashDirectory(targetPath),
-        hashDirectory(expectedSourcePath),
+        hashDirectory(targetPath, { symlinkPolicy: "preserve-safe" }),
+        hashDirectory(expectedSourcePath, { symlinkPolicy: "preserve-safe" }),
       ]);
       return targetHash === contentHash && sourceHash === contentHash;
     } catch {

--- a/packages/core-engine/src/services/doctor-service.ts
+++ b/packages/core-engine/src/services/doctor-service.ts
@@ -150,7 +150,7 @@ export class DoctorService {
               });
             }
           } else {
-            const onDiskHash = await hashDirectory(targetPath);
+            const onDiskHash = await hashDirectory(targetPath, { symlinkPolicy: "preserve-safe" });
             if (onDiskHash !== deployment.contentHash) {
               issues.push({
                 severity: "warning",

--- a/packages/core-engine/src/services/inventory-service.ts
+++ b/packages/core-engine/src/services/inventory-service.ts
@@ -92,6 +92,17 @@ export class InventoryService {
 
       const safeName = slugify(parsed.name) || linkName || sourceId;
 
+      let contentHash: string;
+      try {
+        contentHash = await hashDirectory(leafRoot, { symlinkPolicy: "preserve-safe" });
+      } catch (error) {
+        invalidLeafs.push({
+          path: relativePath,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
+
       candidates.push({
         id: `${sourceId}:${relativePath}`,
         sourceId,
@@ -102,7 +113,7 @@ export class InventoryService {
         relativePath,
         absolutePath: leafRoot,
         skillFilePath,
-        contentHash: await hashDirectory(leafRoot),
+        contentHash,
         diagnostics: parsed.metadataWarnings.map((message) => ({
           code: "LEAF_METADATA_WARNING",
           message,

--- a/packages/core-engine/src/services/skill-collection-materializer.ts
+++ b/packages/core-engine/src/services/skill-collection-materializer.ts
@@ -83,7 +83,7 @@ export async function materializeSkillCollectionMembers(
       const memberPath = path.join(collectionRoot, memberId);
 
       await fs.cp(origin.sourcePath, memberPath, { recursive: true, force: true });
-      const actualHash = await hashDirectory(memberPath);
+      const actualHash = await hashDirectory(memberPath, { symlinkPolicy: "preserve-safe" });
       if (actualHash !== origin.contentHashAtCapture) {
         options.onContentHashMismatch?.({
           collectionRoot,

--- a/packages/core-engine/src/services/source-authority-service.ts
+++ b/packages/core-engine/src/services/source-authority-service.ts
@@ -8,6 +8,7 @@ import type {
   SourceRevision,
   SourceKind,
   SourceManifestRecord,
+  SourceRepairReason,
   SourceUpdateDiff,
   SourceUpdateFailureItem,
   SourceUpdateResult,
@@ -289,6 +290,7 @@ export class SourceAuthorityService {
     const updated: SourceUpdateResultItem[] = [];
     const failed: SourceUpdateFailureItem[] = [];
     const warnings: Warning[] = [];
+    const precheckFallbackSourceIds: string[] = [];
     const hardFailures: Failure[] = [];
     let appliedCheckoutCount = 0;
 
@@ -308,20 +310,38 @@ export class SourceAuthorityService {
       }
 
       const lockedCommit = this.readLockedCommitSha(lock.revision);
+      let repairReason: SourceRepairReason | undefined;
       if (source.kind === "git" && lockedCommit) {
         try {
           const remoteCommit = await this.options.checkoutService.readGitRemoteHeadCommit(
             source.locator,
-            lock.originBranch ? { branch: lock.originBranch } : {},
           );
-          if (remoteCommit && remoteCommit === lockedCommit) {
-            updated.push(this.emptyUpdateResult(sourceId));
-            continue;
+          if (!remoteCommit) {
+            precheckFallbackSourceIds.push(sourceId);
+            warnings.push({
+              code: "SOURCE_REMOTE_PRECHECK_FALLBACK",
+              message: `Remote HEAD could not be verified for '${sourceId}'; running a full update.`,
+            });
+          }
+          if (
+            remoteCommit
+            && remoteCommit === lockedCommit
+          ) {
+            const integrity = await this.inspectCheckoutIntegrity(
+              lock,
+              nextLockFile.leafInventory,
+            );
+            if (!integrity.repairReason) {
+              updated.push(this.emptyUpdateResult(sourceId));
+              continue;
+            }
+            repairReason = integrity.repairReason;
           }
         } catch (error) {
+          precheckFallbackSourceIds.push(sourceId);
           warnings.push({
-            code: "SOURCE_REMOTE_COMMIT_CHECK_FAILED",
-            message: `Unable to verify remote commit for '${sourceId}': ${String(error)}`,
+            code: "SOURCE_REMOTE_PRECHECK_FALLBACK",
+            message: `Remote HEAD could not be verified for '${sourceId}'; running a full update: ${String(error)}`,
           });
         }
       }
@@ -387,6 +407,10 @@ export class SourceAuthorityService {
         nextLeafs,
         prepared.data.invalidLeafs ?? [],
       );
+      if (repairReason) {
+        diff.repaired = true;
+        diff.repairReason = repairReason;
+      }
 
       nextLockFile.sources[sourceId] = {
         ...lock,
@@ -426,6 +450,7 @@ export class SourceAuthorityService {
       status,
       updated,
       ...(failed.length > 0 ? { failed } : {}),
+      ...(precheckFallbackSourceIds.length > 0 ? { precheckFallbackSourceIds } : {}),
     }, warnings);
   }
 
@@ -557,6 +582,36 @@ export class SourceAuthorityService {
     return "commit" in revision ? revision.commit : undefined;
   }
 
+  private async inspectCheckoutIntegrity(
+    lock: LockFile["sources"][string],
+    leafInventory: LeafRecord[],
+  ): Promise<{ repairReason?: SourceRepairReason }> {
+    if (!(await pathExists(lock.localPath))) {
+      return { repairReason: "missing-checkout" };
+    }
+
+    const sourceLeafs = leafInventory.filter((leaf) => leaf.sourceId === lock.sourceId);
+    for (const leaf of sourceLeafs) {
+      const leafPath = path.resolve(lock.localPath, leaf.relativePath);
+      const relativeLeafPath = path.relative(lock.localPath, leafPath);
+      if (relativeLeafPath.startsWith("..") || path.isAbsolute(relativeLeafPath)) {
+        return { repairReason: "content-drift" };
+      }
+      if (!(await pathExists(path.join(leafPath, "SKILL.md")))) {
+        return { repairReason: "missing-skill-file" };
+      }
+      try {
+        if (await hashDirectory(leafPath, { symlinkPolicy: "preserve-safe" }) !== leaf.contentHash) {
+          return { repairReason: "content-drift" };
+        }
+      } catch {
+        return { repairReason: "content-drift" };
+      }
+    }
+
+    return {};
+  }
+
   private emptyUpdateResult(sourceId: string): SourceUpdateResultItem {
     return {
       sourceId,
@@ -644,7 +699,7 @@ export class SourceAuthorityService {
       description: leaf.description ?? "",
       absolutePath,
       skillFilePath: path.join(absolutePath, "SKILL.md"),
-      contentHash: await hashDirectory(absolutePath),
+      contentHash: await hashDirectory(absolutePath, { symlinkPolicy: "preserve-safe" }),
       selectors: {
         aliases: [leaf.id, leaf.relativePath].filter((value, index, values) =>
           value && values.indexOf(value) === index

--- a/packages/core-engine/src/services/source-authority-service.ts
+++ b/packages/core-engine/src/services/source-authority-service.ts
@@ -307,6 +307,25 @@ export class SourceAuthorityService {
         continue;
       }
 
+      const lockedCommit = this.readLockedCommitSha(lock.revision);
+      if (source.kind === "git" && lockedCommit) {
+        try {
+          const remoteCommit = await this.options.checkoutService.readGitRemoteHeadCommit(
+            source.locator,
+            lock.originBranch ? { branch: lock.originBranch } : {},
+          );
+          if (remoteCommit && remoteCommit === lockedCommit) {
+            updated.push(this.emptyUpdateResult(sourceId));
+            continue;
+          }
+        } catch (error) {
+          warnings.push({
+            code: "SOURCE_REMOTE_COMMIT_CHECK_FAILED",
+            message: `Unable to verify remote commit for '${sourceId}': ${String(error)}`,
+          });
+        }
+      }
+
       const tempCheckoutPath = path.join(
         this.options.stateStore.rootPath,
         "source",
@@ -532,6 +551,10 @@ export class SourceAuthorityService {
 
   private mapSourceKind(kind: PreparedSourceCheckout["kind"]): SourceKind {
     return kind;
+  }
+
+  private readLockedCommitSha(revision: SourceRevision): string | undefined {
+    return "commit" in revision ? revision.commit : undefined;
   }
 
   private emptyUpdateResult(sourceId: string): SourceUpdateResultItem {

--- a/packages/core-engine/src/services/source-checkout-service.ts
+++ b/packages/core-engine/src/services/source-checkout-service.ts
@@ -256,6 +256,42 @@ export class SourceCheckoutService {
     }, snapshot.warnings);
   }
 
+  async readGitRemoteHeadCommit(
+    locator: string,
+    options: { branch?: string } = {},
+  ): Promise<string | undefined> {
+    if (!(await isGitAvailable())) {
+      return undefined;
+    }
+
+    const parseCommitSha = (raw: string): string | undefined => {
+      const line = raw
+        .split(/\r?\n/)
+        .map((entry) => entry.trim())
+        .find((entry) => entry.length > 0);
+      const sha = line?.split(/\s+/)[0]?.trim();
+      return sha && /^[0-9a-f]{40}$/i.test(sha) ? sha : undefined;
+    };
+
+    if (options.branch) {
+      const branchRef = `refs/heads/${options.branch}`;
+      const branchOutput = await withNetworkRetries(
+        () => git(["ls-remote", locator, branchRef], { timeoutMs: 30_000 }),
+        { attempts: 2 },
+      );
+      const branchCommit = parseCommitSha(branchOutput);
+      if (branchCommit) {
+        return branchCommit;
+      }
+    }
+
+    const headOutput = await withNetworkRetries(
+      () => git(["ls-remote", locator, "HEAD"], { timeoutMs: 30_000 }),
+      { attempts: 2 },
+    );
+    return parseCommitSha(headOutput);
+  }
+
   async normalizeLocator(locator: string): Promise<string> {
     const trimmed = locator.trim();
 

--- a/packages/core-engine/src/services/source-checkout-service.ts
+++ b/packages/core-engine/src/services/source-checkout-service.ts
@@ -256,10 +256,7 @@ export class SourceCheckoutService {
     }, snapshot.warnings);
   }
 
-  async readGitRemoteHeadCommit(
-    locator: string,
-    options: { branch?: string } = {},
-  ): Promise<string | undefined> {
+  async readGitRemoteHeadCommit(locator: string): Promise<string | undefined> {
     if (!(await isGitAvailable())) {
       return undefined;
     }
@@ -270,25 +267,10 @@ export class SourceCheckoutService {
         .map((entry) => entry.trim())
         .find((entry) => entry.length > 0);
       const sha = line?.split(/\s+/)[0]?.trim();
-      return sha && /^[0-9a-f]{40}$/i.test(sha) ? sha : undefined;
+      return sha && /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(sha) ? sha : undefined;
     };
 
-    if (options.branch) {
-      const branchRef = `refs/heads/${options.branch}`;
-      const branchOutput = await withNetworkRetries(
-        () => git(["ls-remote", locator, branchRef], { timeoutMs: 30_000 }),
-        { attempts: 2 },
-      );
-      const branchCommit = parseCommitSha(branchOutput);
-      if (branchCommit) {
-        return branchCommit;
-      }
-    }
-
-    const headOutput = await withNetworkRetries(
-      () => git(["ls-remote", locator, "HEAD"], { timeoutMs: 30_000 }),
-      { attempts: 2 },
-    );
+    const headOutput = await git(["ls-remote", locator, "HEAD"], { timeoutMs: 5_000 });
     return parseCommitSha(headOutput);
   }
 

--- a/packages/core-engine/src/tests/source-authority-service.test.ts
+++ b/packages/core-engine/src/tests/source-authority-service.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import { StateStore } from "@skill-flow/storage/state-store";
+import { hashDirectory } from "@skill-flow/integration/utils/fs";
 import { InventoryService } from "../services/inventory-service.js";
 import { SourceAuthorityService } from "../services/source-authority-service.js";
 import { SourceCheckoutService } from "../services/source-checkout-service.js";
@@ -216,7 +217,7 @@ describe.sequential("SourceAuthorityService", () => {
     ]);
   });
 
-  test("updateSources skips git refresh when remote commit is unchanged", async () => {
+  test("updateSources skips healthy git sources and repairs local drift", async () => {
     const stateStore = new StateStore(sandbox.stateRoot);
     await stateStore.init();
     const checkoutService = new SourceCheckoutService({
@@ -240,6 +241,7 @@ describe.sequential("SourceAuthorityService", () => {
       skillDoc("one", "One."),
       "utf8",
     );
+    const contentHash = await hashDirectory(path.join(preparedCheckoutPath, "skills", "one"));
     const committed = await service.commitPreparedSource({
       preparedCheckout: {
         locator: "https://github.com/acme/skills.git",
@@ -257,7 +259,7 @@ describe.sequential("SourceAuthorityService", () => {
           relativePath: "skills/one",
           absolutePath: path.join(preparedCheckoutPath, "skills", "one"),
           skillFilePath: path.join(preparedCheckoutPath, "skills", "one", "SKILL.md"),
-          contentHash: "hash-one",
+          contentHash,
           diagnostics: [],
           valid: true,
         }],
@@ -270,12 +272,13 @@ describe.sequential("SourceAuthorityService", () => {
       return;
     }
 
-    checkoutService.readGitRemoteHeadCommit = vi.fn(async () => "same-sha");
-    let prepareCalled = false;
-    checkoutService.prepareSourceCheckout = vi.fn(async () => {
-      prepareCalled = true;
-      throw new Error("prepareSourceCheckout should not be called when commit is unchanged");
+    const recoveryRepo = await createRepo(sandbox.sandboxRoot, {
+      "skills/one/SKILL.md": skillDoc("one", "One."),
     });
+    checkoutService.readGitRemoteHeadCommit = vi.fn(async () => "same-sha");
+    const originalPrepareSourceCheckout = checkoutService.prepareSourceCheckout.bind(checkoutService);
+    const prepareSourceCheckout = vi.spyOn(checkoutService, "prepareSourceCheckout")
+      .mockImplementation((_locator, options) => originalPrepareSourceCheckout(recoveryRepo, options));
 
     const updated = await service.updateSources(["git-unchanged"]);
 
@@ -283,7 +286,7 @@ describe.sequential("SourceAuthorityService", () => {
     if (!updated.ok) {
       return;
     }
-    expect(prepareCalled).toBe(false);
+    expect(prepareSourceCheckout).not.toHaveBeenCalled();
     expect(updated.data.updated).toEqual([
       expect.objectContaining({
         sourceId: "git-unchanged",
@@ -294,6 +297,122 @@ describe.sequential("SourceAuthorityService", () => {
     expect(state.lockFile.sources["git-unchanged"]?.leafIds).toEqual([
       "git-unchanged:skills/one",
     ]);
+
+    await fs.rm(state.lockFile.sources["git-unchanged"]!.localPath, {
+      recursive: true,
+      force: true,
+    });
+
+    const restored = await service.updateSources(["git-unchanged"]);
+
+    expect(restored.ok).toBe(true);
+    expect(prepareSourceCheckout).toHaveBeenCalledTimes(1);
+    if (!restored.ok) {
+      return;
+    }
+    expect(restored.data.updated[0]).toEqual(expect.objectContaining({
+      sourceId: "git-unchanged",
+      changed: false,
+      repaired: true,
+      repairReason: "missing-checkout",
+    }));
+    await expect(fs.stat(path.join(
+      sandbox.stateRoot,
+      "source",
+      "git",
+      "git-unchanged",
+      "skills",
+      "one",
+      "SKILL.md",
+    ))).resolves.toBeTruthy();
+
+    await fs.rm(path.join(
+      sandbox.stateRoot,
+      "source",
+      "git",
+      "git-unchanged",
+      "skills",
+      "one",
+      "SKILL.md",
+    ));
+    const repairedSkillFile = await service.updateSources(["git-unchanged"]);
+    expect(repairedSkillFile.ok).toBe(true);
+    if (!repairedSkillFile.ok) {
+      return;
+    }
+    expect(repairedSkillFile.data.updated[0]).toEqual(expect.objectContaining({
+      repaired: true,
+      repairReason: "missing-skill-file",
+    }));
+
+    await fs.appendFile(path.join(
+      sandbox.stateRoot,
+      "source",
+      "git",
+      "git-unchanged",
+      "skills",
+      "one",
+      "SKILL.md",
+    ), "\nlocal drift\n");
+    const repairedContent = await service.updateSources(["git-unchanged"]);
+    expect(repairedContent.ok).toBe(true);
+    if (!repairedContent.ok) {
+      return;
+    }
+    expect(repairedContent.data.updated[0]).toEqual(expect.objectContaining({
+      repaired: true,
+      repairReason: "content-drift",
+    }));
+    expect(prepareSourceCheckout).toHaveBeenCalledTimes(3);
+  });
+
+  test("updateSources falls back to a full update when remote HEAD preflight is unavailable", async () => {
+    const repoPath = await createRepo(sandbox.sandboxRoot, {
+      "skills/one/SKILL.md": skillDoc("one", "One."),
+    });
+    const stateStore = new StateStore(sandbox.stateRoot);
+    await stateStore.init();
+    const checkoutService = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+    const service = new SourceAuthorityService({ stateStore, checkoutService });
+    const added = await service.addSource(repoPath, { sourceIdOverride: "git-fallback" });
+    expect(added.ok).toBe(true);
+    if (!added.ok) {
+      return;
+    }
+
+    const state = await stateStore.readState();
+    state.manifest.sources[0] = {
+      ...state.manifest.sources[0]!,
+      kind: "git",
+      locator: "https://github.com/acme/skills.git",
+    };
+    state.lockFile.sources["git-fallback"] = {
+      ...state.lockFile.sources["git-fallback"]!,
+      revision: { provider: "git", commit: "same-sha", capturedAt: new Date().toISOString() },
+    };
+    await stateStore.writeState(state);
+
+    checkoutService.readGitRemoteHeadCommit = vi.fn(async () => undefined);
+    const originalPrepareSourceCheckout = checkoutService.prepareSourceCheckout.bind(checkoutService);
+    const prepareSourceCheckout = vi.spyOn(checkoutService, "prepareSourceCheckout")
+      .mockImplementation((_locator, options) => originalPrepareSourceCheckout(repoPath, options));
+
+    const updated = await service.updateSources(["git-fallback"]);
+
+    expect(updated.ok).toBe(true);
+    if (!updated.ok) {
+      return;
+    }
+    expect(prepareSourceCheckout).toHaveBeenCalledTimes(1);
+    expect(updated.data.precheckFallbackSourceIds).toEqual(["git-fallback"]);
+    expect(updated.warnings).toContainEqual(expect.objectContaining({
+      code: "SOURCE_REMOTE_PRECHECK_FALLBACK",
+    }));
+    expect(updated.data.updated[0]).toEqual(expect.objectContaining({ changed: false }));
+    expect(updated.data.updated[0]?.repaired).toBeUndefined();
   });
 
   test("updateSources keeps successful groups when another group fails mid-batch", async () => {

--- a/packages/core-engine/src/tests/source-authority-service.test.ts
+++ b/packages/core-engine/src/tests/source-authority-service.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { StateStore } from "@skill-flow/storage/state-store";
 import { InventoryService } from "../services/inventory-service.js";
 import { SourceAuthorityService } from "../services/source-authority-service.js";
@@ -213,6 +213,86 @@ describe.sequential("SourceAuthorityService", () => {
     expect(state.lockFile.sources["update-source"]?.leafIds).toEqual([
       "update-source:skills/one",
       "update-source:skills/two",
+    ]);
+  });
+
+  test("updateSources skips git refresh when remote commit is unchanged", async () => {
+    const stateStore = new StateStore(sandbox.stateRoot);
+    await stateStore.init();
+    const checkoutService = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+    const service = new SourceAuthorityService({
+      stateStore,
+      checkoutService,
+    });
+
+    const preparedCheckoutPath = path.join(
+      sandbox.stateRoot,
+      "source",
+      "git",
+      ".prepared-git-unchanged",
+    );
+    await fs.mkdir(path.join(preparedCheckoutPath, "skills", "one"), { recursive: true });
+    await fs.writeFile(
+      path.join(preparedCheckoutPath, "skills", "one", "SKILL.md"),
+      skillDoc("one", "One."),
+      "utf8",
+    );
+    const committed = await service.commitPreparedSource({
+      preparedCheckout: {
+        locator: "https://github.com/acme/skills.git",
+        displayName: "Skills",
+        kind: "git",
+        sourceId: "git-unchanged",
+        checkoutPath: preparedCheckoutPath,
+        leafs: [{
+          id: "git-unchanged:skills/one",
+          sourceId: "git-unchanged",
+          name: "one",
+          linkName: "one",
+          title: "one",
+          description: "One.",
+          relativePath: "skills/one",
+          absolutePath: path.join(preparedCheckoutPath, "skills", "one"),
+          skillFilePath: path.join(preparedCheckoutPath, "skills", "one", "SKILL.md"),
+          contentHash: "hash-one",
+          diagnostics: [],
+          valid: true,
+        }],
+        invalidLeafs: [],
+        commitSha: "same-sha",
+      },
+    });
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) {
+      return;
+    }
+
+    checkoutService.readGitRemoteHeadCommit = vi.fn(async () => "same-sha");
+    let prepareCalled = false;
+    checkoutService.prepareSourceCheckout = vi.fn(async () => {
+      prepareCalled = true;
+      throw new Error("prepareSourceCheckout should not be called when commit is unchanged");
+    });
+
+    const updated = await service.updateSources(["git-unchanged"]);
+
+    expect(updated.ok).toBe(true);
+    if (!updated.ok) {
+      return;
+    }
+    expect(prepareCalled).toBe(false);
+    expect(updated.data.updated).toEqual([
+      expect.objectContaining({
+        sourceId: "git-unchanged",
+        changed: false,
+      }),
+    ]);
+    const state = await stateStore.readState();
+    expect(state.lockFile.sources["git-unchanged"]?.leafIds).toEqual([
+      "git-unchanged:skills/one",
     ]);
   });
 

--- a/packages/core-engine/src/tests/source-checkout-service.test.ts
+++ b/packages/core-engine/src/tests/source-checkout-service.test.ts
@@ -39,7 +39,7 @@ describe.sequential("SourceCheckoutService", () => {
 
   test("reads remote HEAD commit for git locators", async () => {
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
-    vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
+    const git = vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
       if (args[0] === "ls-remote" && args[2] === "HEAD") {
         return "0123456789abcdef0123456789abcdef01234567\tHEAD";
       }
@@ -53,6 +53,24 @@ describe.sequential("SourceCheckoutService", () => {
     await expect(
       service.readGitRemoteHeadCommit("https://github.com/acme/skills.git"),
     ).resolves.toBe("0123456789abcdef0123456789abcdef01234567");
+    expect(git).toHaveBeenCalledWith(
+      ["ls-remote", "https://github.com/acme/skills.git", "HEAD"],
+      { timeoutMs: 5_000 },
+    );
+  });
+
+  test("accepts SHA-256 remote HEAD commits", async () => {
+    const sha256 = "0123456789abcdef".repeat(4);
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
+    vi.spyOn(gitUtils, "git").mockResolvedValue(`${sha256}\tHEAD`);
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    await expect(
+      service.readGitRemoteHeadCommit("https://github.com/acme/skills.git"),
+    ).resolves.toBe(sha256);
   });
 
   test("prepares a checkout snapshot without writing authority files", async () => {
@@ -102,6 +120,30 @@ describe.sequential("SourceCheckoutService", () => {
     await expect(fs.access(path.join(sandbox.stateRoot, "lock.json"))).rejects.toThrow();
     await expect(fs.access(path.join(sandbox.stateRoot, "preferences.json"))).rejects.toThrow();
     await expect(fs.access(path.join(sandbox.stateRoot, "collections.json"))).rejects.toThrow();
+  });
+
+  test("rejects skill leafs with escaping symlinks before they can be deployed", async () => {
+    const repoPath = await createRepo(sandbox.sandboxRoot, {
+      "skills/unsafe/SKILL.md": skillDoc("unsafe", "Unsafe skill."),
+    });
+    await fs.symlink("../../outside", path.join(repoPath, "skills", "unsafe", "escape"));
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    const prepared = await service.prepareSourceCheckout(repoPath, {
+      options: { sourceIdOverride: "unsafe-source" },
+    });
+
+    expect(prepared.ok).toBe(false);
+    if (prepared.ok) {
+      return;
+    }
+    expect(prepared.warnings).toContainEqual(expect.objectContaining({
+      code: "INVALID_LEAF",
+      message: expect.stringContaining("Unsafe symbolic link"),
+    }));
   });
 
   test("prepares GitHub tree locators under the git source root", async () => {

--- a/packages/core-engine/src/tests/source-checkout-service.test.ts
+++ b/packages/core-engine/src/tests/source-checkout-service.test.ts
@@ -37,6 +37,24 @@ describe.sequential("SourceCheckoutService", () => {
       });
   });
 
+  test("reads remote HEAD commit for git locators", async () => {
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
+    vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
+      if (args[0] === "ls-remote" && args[2] === "HEAD") {
+        return "0123456789abcdef0123456789abcdef01234567\tHEAD";
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    await expect(
+      service.readGitRemoteHeadCommit("https://github.com/acme/skills.git"),
+    ).resolves.toBe("0123456789abcdef0123456789abcdef01234567");
+  });
+
   test("prepares a checkout snapshot without writing authority files", async () => {
     const repoPath = await createRepo(sandbox.sandboxRoot, {
       "skills/frontend-design/SKILL.md": skillDoc("frontend-design", "Design frontends."),

--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -1046,9 +1046,16 @@ export type SourceUpdateDiff = {
   diagnostics?: Diagnostic[];
 };
 
+export type SourceRepairReason =
+  | "missing-checkout"
+  | "missing-skill-file"
+  | "content-drift";
+
 export type SourceUpdateResultItem = {
   sourceId: SourceId;
   changed: boolean;
+  repaired?: boolean;
+  repairReason?: SourceRepairReason;
   requestedPath?: string;
   selectionMode?: "all" | "selected";
   addedLeafIds: string[];
@@ -1069,6 +1076,8 @@ export type SourceUpdateResult = {
   updated: SourceUpdateResultItem[];
   /** Groups that failed during a multi-source update; disk/lock were left unchanged for these. */
   failed?: SourceUpdateFailureItem[];
+  /** Sources that used the full update path because remote HEAD preflight was unavailable. */
+  precheckFallbackSourceIds?: SourceId[];
   diffs?: SourceUpdateDiff[];
   diagnostics?: Diagnostic[];
 };

--- a/packages/integration/src/tests/fs-utils.test.ts
+++ b/packages/integration/src/tests/fs-utils.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { hashDirectory } from "../utils/fs.js";
+
+describe("hashDirectory", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+  });
+
+  test("hashes safe relative symlinks without dereferencing them", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-fs-"));
+    roots.push(root);
+    await fs.writeFile(path.join(root, "target.md"), "one", "utf8");
+    await fs.symlink("target.md", path.join(root, "alias.md"));
+
+    const firstHash = await hashDirectory(root, { symlinkPolicy: "preserve-safe" });
+    await fs.writeFile(path.join(root, "target.md"), "two", "utf8");
+
+    await expect(hashDirectory(root, { symlinkPolicy: "preserve-safe" })).resolves.not.toBe(firstHash);
+  });
+
+  test("rejects absolute and escaping symlinks", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-fs-"));
+    roots.push(root);
+    await fs.symlink("../outside", path.join(root, "escape"));
+
+    await expect(hashDirectory(root, { symlinkPolicy: "preserve-safe" })).rejects.toThrow("Unsafe symbolic link");
+  });
+});

--- a/packages/integration/src/utils/fs.ts
+++ b/packages/integration/src/utils/fs.ts
@@ -130,8 +130,12 @@ export async function isBrokenSymlink(targetPath: string): Promise<boolean> {
   }
 }
 
-export async function hashDirectory(rootPath: string): Promise<string> {
+export async function hashDirectory(
+  rootPath: string,
+  options: { symlinkPolicy?: "ignore" | "preserve-safe" } = {},
+): Promise<string> {
   const hash = crypto.createHash("sha256");
+  const resolvedRootPath = path.resolve(rootPath);
 
   async function walk(currentPath: string): Promise<void> {
     const entries = await fs.readdir(currentPath, { withFileTypes: true });
@@ -152,6 +156,20 @@ export async function hashDirectory(rootPath: string): Promise<string> {
       } else if (entry.isFile()) {
         hash.update("file");
         hash.update(await fs.readFile(entryPath));
+      } else if (entry.isSymbolicLink()) {
+        if (options.symlinkPolicy !== "preserve-safe") {
+          continue;
+        }
+        const target = await fs.readlink(entryPath);
+        const resolvedTarget = path.resolve(path.dirname(entryPath), target);
+        if (
+          path.isAbsolute(target)
+          || (resolvedTarget !== resolvedRootPath && !isPathInside(resolvedRootPath, resolvedTarget))
+        ) {
+          throw new Error(`Unsafe symbolic link '${relativePath}' escapes '${rootPath}'.`);
+        }
+        hash.update("symlink");
+        hash.update(target);
       }
     }
   }

--- a/packages/query/src/runtime.ts
+++ b/packages/query/src/runtime.ts
@@ -1711,7 +1711,10 @@ export class SkillFlowApp {
         continue;
       }
 
-      const currentHash = await hashDirectory(originLeaf.absolutePath).catch(() => undefined);
+      const currentHash = await hashDirectory(
+        originLeaf.absolutePath,
+        { symlinkPolicy: "preserve-safe" },
+      ).catch(() => undefined);
       if (!currentHash) {
         diagnostics.push({
           code: "COLLECTION_ORIGIN_UNAVAILABLE",
@@ -1844,7 +1847,7 @@ export class SkillFlowApp {
       path: resolvedPath,
       displayName,
       sourceId: deriveSourceId(resolvedPath),
-      contentHash: await hashDirectory(resolvedPath),
+      contentHash: await hashDirectory(resolvedPath, { symlinkPolicy: "preserve-safe" }),
       importedFromTargets: observedTargets.map((target) => target.target),
       observedTargets,
       title: metadata.title || displayName,
@@ -5079,7 +5082,24 @@ export class SkillFlowApp {
     return this.runAuditedMutation(
       "update-sources",
       { sourceIds: sourceIds ?? [] },
-      () => this.updateSourcesImpl(sourceIds),
+      async () => {
+        const result = await this.updateSourcesImpl(sourceIds);
+        if (!result.ok) {
+          return result;
+        }
+        const repaired = result.data.updated.filter((item) => item.repaired);
+        return {
+          result,
+          auditDetails: {
+            repairedSourceIds: repaired.map((item) => item.sourceId),
+            repairReasons: repaired.map((item) => ({
+              sourceId: item.sourceId,
+              reason: item.repairReason,
+            })),
+            precheckFallbackSourceIds: result.data.precheckFallbackSourceIds ?? [],
+          },
+        };
+      },
     );
   }
 
@@ -7247,7 +7267,7 @@ export class SkillFlowApp {
       if (!stats.isDirectory()) {
         return false;
       }
-      const onDiskHash = await hashDirectory(targetPath);
+      const onDiskHash = await hashDirectory(targetPath, { symlinkPolicy: "preserve-safe" });
       return onDiskHash === leaf.contentHash;
     } catch {
       return false;

--- a/packages/query/src/tests/source-lifecycle.test.ts
+++ b/packages/query/src/tests/source-lifecycle.test.ts
@@ -1306,6 +1306,108 @@ description: |
     expect(await fs.readFile(path.join(targetPath, "SKILL.md"), "utf8")).toBe(targetBefore);
   });
 
+  test("update repairs an unchanged git checkout, reconciles its target, and audits the repair", async () => {
+    const repoPath = await createRepo(sandbox.sandboxRoot, {
+      "browse/SKILL.md": skillDoc("browse", "Browser flow."),
+    });
+    const app = new SkillFlowApp();
+    const added = await app.addSource(repoPath, { sourceIdOverride: "git-repair" });
+    expect(added.ok).toBe(true);
+    if (!added.ok) {
+      return;
+    }
+
+    const sourceId = added.data.manifest.id;
+    const leafId = `${sourceId}:browse`;
+    const applied = await app.applyDraft(sourceId, {
+      enabledTargets: ["codex"],
+      selectedLeafIds: [leafId],
+    });
+    expect(applied.ok).toBe(true);
+    if (!applied.ok) {
+      return;
+    }
+
+    const before = await view(app);
+    const targetPath = before.lockFile.projections.find(
+      (projection) => projection.sourceId === sourceId && projection.target === "codex",
+    )?.targetPath;
+    expect(targetPath).toBeTruthy();
+    if (!targetPath) {
+      return;
+    }
+    const commit = await gitUtils.git(["rev-parse", "HEAD"], { cwd: repoPath });
+    await v2(app).writeState({
+      ...before,
+      manifest: {
+        ...before.manifest,
+        sources: before.manifest.sources.map((source) => source.id === sourceId
+          ? { ...source, kind: "git" }
+          : source),
+      },
+      lockFile: {
+        ...before.lockFile,
+        sources: {
+          ...before.lockFile.sources,
+          [sourceId]: {
+            ...before.lockFile.sources[sourceId]!,
+            revision: { provider: "git", commit, capturedAt: new Date().toISOString() },
+          },
+        },
+      },
+    });
+    await fs.rm(before.lockFile.sources[sourceId]!.localPath, { recursive: true, force: true });
+    await fs.rm(targetPath, { recursive: true, force: true });
+
+    const updated = await app.updateSources([sourceId]);
+
+    expect(updated.ok).toBe(true);
+    if (!updated.ok) {
+      return;
+    }
+    expect(updated.data.updated[0]).toMatchObject({
+      sourceId,
+      changed: false,
+      repaired: true,
+      repairReason: "missing-checkout",
+    });
+    await expect(fs.stat(path.join(targetPath, "SKILL.md"))).resolves.toBeTruthy();
+
+    const auditLines = (await fs.readFile(path.join(sandbox.stateRoot, "audit.log.jsonl"), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(auditLines.at(-1)).toMatchObject({
+      mutation: "update-sources",
+      status: "ok",
+      details: {
+        repairedSourceIds: [sourceId],
+        repairReasons: [{ sourceId, reason: "missing-checkout" }],
+        precheckFallbackSourceIds: [],
+      },
+    });
+
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(false);
+    const fallback = await app.updateSources([sourceId]);
+    expect(fallback.ok).toBe(true);
+    if (!fallback.ok) {
+      return;
+    }
+    expect(fallback.warnings).toContainEqual(expect.objectContaining({
+      code: "SOURCE_REMOTE_PRECHECK_FALLBACK",
+    }));
+    const fallbackAuditLines = (await fs.readFile(path.join(sandbox.stateRoot, "audit.log.jsonl"), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(fallbackAuditLines.at(-1)).toMatchObject({
+      details: {
+        repairedSourceIds: [],
+        precheckFallbackSourceIds: [sourceId],
+      },
+    });
+  });
+
   test("applyDraft writes an audit event with selected targets", async () => {
     const repoPath = await createRepo(sandbox.sandboxRoot, {
       "skills/review/SKILL.md": skillDoc("review", "Review code."),

--- a/packages/tui/src/config-app.tsx
+++ b/packages/tui/src/config-app.tsx
@@ -1201,11 +1201,14 @@ export function ConfigApp({
       setTargetCursor(nextFocusState.agentCursor);
       setSkillCursor(nextFocusState.skillCursor);
       setActionCursor(nextFocusState.actionCursor);
+      const sourceUpdate = result.data.updated.find((item) => item.sourceId === sourceId);
       setUpdateStateBySourceId((current) => ({
         ...pruneSourceMap(current, nextIds),
         [sourceId]: {
           phase: "updated",
-          message: "updated",
+          message: sourceUpdate?.repaired
+            ? `repaired (${sourceUpdate.repairReason})`
+            : "updated",
         },
       }));
 


### PR DESCRIPTION
This pull request introduces an optimization to the source update process for Git sources, ensuring that sources are not unnecessarily refreshed if the remote commit has not changed. It also adds supporting functionality and tests for reading the remote HEAD commit from a Git repository.

**Optimization for Git source updates:**

* The `SourceAuthorityService` now checks the remote HEAD commit for Git sources before performing a refresh. If the remote commit matches the locked commit, the refresh is skipped, improving efficiency.
* Added the helper method `readLockedCommitSha` to extract the commit SHA from a `SourceRevision` object.

**New functionality for reading remote commits:**

* Implemented `readGitRemoteHeadCommit` in `SourceCheckoutService` to retrieve the remote HEAD (or branch) commit SHA from a Git locator, with network retry logic.

**Test coverage:**

* Added a test to verify that `updateSources` skips the refresh if the remote commit is unchanged, and that `prepareSourceCheckout` is not called in this case.
* Added a test for `readGitRemoteHeadCommit` to confirm it correctly reads the remote HEAD commit from a Git repository.
* Updated test imports to include `vi` for mocking.