### PR TITLE
Improve managed Git updates with remote preflight and safe staged refresh

### DIFF
--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
@@ -108,20 +108,23 @@ final class BridgeClient: @unchecked Sendable {
     private let mutationCoordinator = MutationCoordinator()
     private let commandTimeoutMilliseconds: UInt64
     private let importCommandTimeoutMilliseconds: UInt64
-    private let updateCommandTimeoutMilliseconds: UInt64?
+    private let updateSourceTimeoutMilliseconds: UInt64
+    private let updateCommandMaximumTimeoutMilliseconds: UInt64
     private let commandTimeoutGraceMilliseconds: UInt64
 
     init(
         commandTimeoutMilliseconds: UInt64 = 60_000,
         // Network-heavy import/add work often needs more than 3 minutes on unstable links.
         importCommandTimeoutMilliseconds: UInt64 = 300_000,
-        // Each update step is bounded by the helper; the source count is not.
-        updateCommandTimeoutMilliseconds: UInt64? = nil,
+        // One source receives five minutes; selected updates scale to a 15-minute ceiling.
+        updateSourceTimeoutMilliseconds: UInt64 = 300_000,
+        updateCommandMaximumTimeoutMilliseconds: UInt64 = 900_000,
         commandTimeoutGraceMilliseconds: UInt64 = 1_000
     ) {
         self.commandTimeoutMilliseconds = commandTimeoutMilliseconds
         self.importCommandTimeoutMilliseconds = importCommandTimeoutMilliseconds
-        self.updateCommandTimeoutMilliseconds = updateCommandTimeoutMilliseconds
+        self.updateSourceTimeoutMilliseconds = updateSourceTimeoutMilliseconds
+        self.updateCommandMaximumTimeoutMilliseconds = updateCommandMaximumTimeoutMilliseconds
         self.commandTimeoutGraceMilliseconds = commandTimeoutGraceMilliseconds
     }
 
@@ -429,7 +432,7 @@ final class BridgeClient: @unchecked Sendable {
         inputPipe.fileHandleForWriting.write(requestData)
         inputPipe.fileHandleForWriting.closeFile()
 
-        let activeTimeoutMilliseconds = timeoutMilliseconds(for: command)
+        let activeTimeoutMilliseconds = timeoutMilliseconds(for: command, payload: payload)
         let didExit = await waitForProcessExit(
             process,
             state: exitWaitState,
@@ -437,9 +440,6 @@ final class BridgeClient: @unchecked Sendable {
         )
 
         if !didExit {
-            guard let activeTimeoutMilliseconds else {
-                preconditionFailure("An unbounded process wait cannot time out")
-            }
             outputPipe.fileHandleForReading.readabilityHandler = nil
             errorPipe.fileHandleForReading.readabilityHandler = nil
             process.terminationHandler = nil
@@ -500,9 +500,24 @@ final class BridgeClient: @unchecked Sendable {
         throw BridgeClientError.commandFailed(message, response: response)
     }
 
-    private func timeoutMilliseconds(for command: BridgeCommand) -> UInt64? {
+    private func timeoutMilliseconds(
+        for command: BridgeCommand,
+        payload: [String: AnyCodable]?
+    ) -> UInt64 {
         if command == .update {
-            return updateCommandTimeoutMilliseconds
+            guard
+                let sourceIds = payload?["sourceIds"]?.value as? [String],
+                !sourceIds.isEmpty
+            else {
+                return updateCommandMaximumTimeoutMilliseconds
+            }
+            let sourceCount = UInt64(Set(sourceIds).count)
+            let (scaledTimeout, overflow) = updateSourceTimeoutMilliseconds
+                .multipliedReportingOverflow(by: sourceCount)
+            return min(
+                overflow ? updateCommandMaximumTimeoutMilliseconds : scaledTimeout,
+                updateCommandMaximumTimeoutMilliseconds
+            )
         }
         return command.usesExtendedNetworkTimeout
             ? importCommandTimeoutMilliseconds
@@ -512,16 +527,8 @@ final class BridgeClient: @unchecked Sendable {
     private func waitForProcessExit(
         _ process: Process,
         state: ProcessExitWaitState,
-        timeoutMilliseconds: UInt64?
+        timeoutMilliseconds: UInt64
     ) async -> Bool {
-        guard let timeoutMilliseconds else {
-            let outcome = await withCheckedContinuation { continuation in
-                state.setContinuation(continuation)
-            }
-            process.terminationHandler = nil
-            return outcome == .exited
-        }
-
         let timeoutTask = Task {
             try? await Task.sleep(nanoseconds: Self.nanoseconds(fromMilliseconds: timeoutMilliseconds))
             state.resolve(.timedOut)

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
@@ -108,16 +108,20 @@ final class BridgeClient: @unchecked Sendable {
     private let mutationCoordinator = MutationCoordinator()
     private let commandTimeoutMilliseconds: UInt64
     private let importCommandTimeoutMilliseconds: UInt64
+    private let updateCommandTimeoutMilliseconds: UInt64?
     private let commandTimeoutGraceMilliseconds: UInt64
 
     init(
         commandTimeoutMilliseconds: UInt64 = 60_000,
-        // Network-heavy import/update/add work often needs more than 3 minutes on unstable links.
+        // Network-heavy import/add work often needs more than 3 minutes on unstable links.
         importCommandTimeoutMilliseconds: UInt64 = 300_000,
+        // Each update step is bounded by the helper; the source count is not.
+        updateCommandTimeoutMilliseconds: UInt64? = nil,
         commandTimeoutGraceMilliseconds: UInt64 = 1_000
     ) {
         self.commandTimeoutMilliseconds = commandTimeoutMilliseconds
         self.importCommandTimeoutMilliseconds = importCommandTimeoutMilliseconds
+        self.updateCommandTimeoutMilliseconds = updateCommandTimeoutMilliseconds
         self.commandTimeoutGraceMilliseconds = commandTimeoutGraceMilliseconds
     }
 
@@ -433,6 +437,9 @@ final class BridgeClient: @unchecked Sendable {
         )
 
         if !didExit {
+            guard let activeTimeoutMilliseconds else {
+                preconditionFailure("An unbounded process wait cannot time out")
+            }
             outputPipe.fileHandleForReading.readabilityHandler = nil
             errorPipe.fileHandleForReading.readabilityHandler = nil
             process.terminationHandler = nil
@@ -493,8 +500,11 @@ final class BridgeClient: @unchecked Sendable {
         throw BridgeClientError.commandFailed(message, response: response)
     }
 
-    private func timeoutMilliseconds(for command: BridgeCommand) -> UInt64 {
-        command.usesExtendedNetworkTimeout
+    private func timeoutMilliseconds(for command: BridgeCommand) -> UInt64? {
+        if command == .update {
+            return updateCommandTimeoutMilliseconds
+        }
+        return command.usesExtendedNetworkTimeout
             ? importCommandTimeoutMilliseconds
             : commandTimeoutMilliseconds
     }
@@ -502,8 +512,16 @@ final class BridgeClient: @unchecked Sendable {
     private func waitForProcessExit(
         _ process: Process,
         state: ProcessExitWaitState,
-        timeoutMilliseconds: UInt64
+        timeoutMilliseconds: UInt64?
     ) async -> Bool {
+        guard let timeoutMilliseconds else {
+            let outcome = await withCheckedContinuation { continuation in
+                state.setContinuation(continuation)
+            }
+            process.terminationHandler = nil
+            return outcome == .exited
+        }
+
         let timeoutTask = Task {
             try? await Task.sleep(nanoseconds: Self.nanoseconds(fromMilliseconds: timeoutMilliseconds))
             state.resolve(.timedOut)

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
@@ -85,6 +85,24 @@ final class BridgeClientExecutionTests: XCTestCase {
         XCTAssertTrue(response.ok)
     }
 
+    func testUpdateUsesDedicatedLongRunningCommandTimeout() async throws {
+        let fixture = try SlowBridgeFixture.install(delayMilliseconds: 100)
+        self.fixture = fixture
+
+        let bridge = await MainActor.run {
+            BridgeClient(
+                commandTimeoutMilliseconds: 25,
+                importCommandTimeoutMilliseconds: 50,
+                updateCommandTimeoutMilliseconds: 150
+            )
+        }
+
+        let response = try await bridge.updateSources(["hugohe3-ppt-master"])
+
+        XCTAssertEqual(response.command, BridgeCommand.update)
+        XCTAssertTrue(response.ok)
+    }
+
     func testTimedOutHelperIsForceKilledWhenItIgnoresTerminate() async throws {
         let fixture = try StubbornBridgeFixture.install()
         stubbornFixture = fixture

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
@@ -85,7 +85,7 @@ final class BridgeClientExecutionTests: XCTestCase {
         XCTAssertTrue(response.ok)
     }
 
-    func testUpdateUsesDedicatedLongRunningCommandTimeout() async throws {
+    func testUpdateTimeoutScalesWithSelectedSourceCount() async throws {
         let fixture = try SlowBridgeFixture.install(delayMilliseconds: 100)
         self.fixture = fixture
 
@@ -93,14 +93,70 @@ final class BridgeClientExecutionTests: XCTestCase {
             BridgeClient(
                 commandTimeoutMilliseconds: 25,
                 importCommandTimeoutMilliseconds: 50,
-                updateCommandTimeoutMilliseconds: 150
+                updateSourceTimeoutMilliseconds: 75,
+                updateCommandMaximumTimeoutMilliseconds: 150
             )
         }
 
-        let response = try await bridge.updateSources(["hugohe3-ppt-master"])
+        let response = try await bridge.updateSources(["alpha", "beta"])
 
         XCTAssertEqual(response.command, BridgeCommand.update)
         XCTAssertTrue(response.ok)
+    }
+
+    func testSingleSourceUpdateUsesOneSourceBudget() async throws {
+        let fixture = try SlowBridgeFixture.install(delayMilliseconds: 100)
+        self.fixture = fixture
+
+        let bridge = await MainActor.run {
+            BridgeClient(
+                updateSourceTimeoutMilliseconds: 50,
+                updateCommandMaximumTimeoutMilliseconds: 150
+            )
+        }
+
+        do {
+            _ = try await bridge.updateSources(["alpha"])
+            XCTFail("Expected one source update to use one source budget.")
+        } catch {
+            XCTAssertEqual(error.localizedDescription, "Operation timed out after 50ms.")
+        }
+    }
+
+    func testUpdateAllUsesMaximumUpdateBudget() async throws {
+        let fixture = try SlowBridgeFixture.install(delayMilliseconds: 100)
+        self.fixture = fixture
+
+        let bridge = await MainActor.run {
+            BridgeClient(
+                updateSourceTimeoutMilliseconds: 50,
+                updateCommandMaximumTimeoutMilliseconds: 150
+            )
+        }
+
+        let response = try await bridge.updateAll()
+
+        XCTAssertEqual(response.command, BridgeCommand.update)
+        XCTAssertTrue(response.ok)
+    }
+
+    func testSelectedUpdateBudgetDoesNotExceedMaximum() async throws {
+        let fixture = try SlowBridgeFixture.install(delayMilliseconds: 150)
+        self.fixture = fixture
+
+        let bridge = await MainActor.run {
+            BridgeClient(
+                updateSourceTimeoutMilliseconds: 50,
+                updateCommandMaximumTimeoutMilliseconds: 100
+            )
+        }
+
+        do {
+            _ = try await bridge.updateSources(["alpha", "beta", "gamma", "delta"])
+            XCTFail("Expected selected update budget to stop at its maximum.")
+        } catch {
+            XCTAssertEqual(error.localizedDescription, "Operation timed out after 100ms.")
+        }
     }
 
     func testTimedOutHelperIsForceKilledWhenItIgnoresTerminate() async throws {

--- a/docs/FEATURE_INDEX.md
+++ b/docs/FEATURE_INDEX.md
@@ -18,6 +18,7 @@
 | Desktop DMG update flow | Planned | - | [plan](superpowers/plans/2026-06-24-desktop-dmg-update-flow.md) | - |
 | Local scan import source path policy | Planned | [spec](superpowers/specs/2026-06-24-local-scan-import-source-path-policy-design.md) | [plan](superpowers/plans/2026-06-24-local-scan-import-source-path-policy.md) | - |
 | CLI migration usability | Implemented | [spec](superpowers/specs/2026-06-26-cli-migration-usability-design.md) | [plan](superpowers/plans/2026-06-26-cli-migration-usability.md) | - |
+| Git source update boundaries | Implemented | [spec](superpowers/specs/2026-08-18-git-source-update-boundaries-design.md) | - | Focused source, query, and desktop bridge tests |
 | Plugin assets and target routing | Issue | - | [analysis](issues/ISSUE_8_plugin_assets_and_target_routing.md), [user report](issues/ISSUE_8_plugin_assets_and_target_routing_user_report.md) | - |
 | Group card state matrix | Verification | - | - | [matrix](verification/GROUP_CARD_STATE_MATRIX.md) |
 | Mount lifecycle edge cases | Verification | - | - | [matrix](verification/mount-lifecycle-matrix.md) |

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -31,6 +31,9 @@ Skill Flow 用来把分散在不同来源的 AI agent skills 管理成可检查�
 - `lock.json` 记录解析结果、source snapshot 和部署投影。
 - Target 目录是生成输出，不是事实源。
 - macOS 桌面端依赖 CLI bridge 协议，不另建第二套状态模型。
+- GitHub tree URL 的 branch/path 边界通过远端分支确认；无法确认时明确失败，不按路径片段猜测。
+- Managed update 只读写 `~/.skillflow/source/<kind>/<sourceId>` 的规范 checkout；lock 路径不匹配时拒绝更新。
+- 桌面端更新始终有界：每个明确选择的 source 预算 5 分钟，总上限 15 分钟；全部更新使用 15 分钟。
 
 ## 非目标
 
@@ -48,4 +51,3 @@ Skill Flow 用来把分散在不同来源的 AI agent skills 管理成可检查�
 - bridge protocol request/response。
 - desktop bridge payload 或打包产物行为。
 - README、release notes 中承诺的用户流程。
-

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -31,8 +31,7 @@ Skill Flow 用来把分散在不同来源的 AI agent skills 管理成可检查�
 - `lock.json` 记录解析结果、source snapshot 和部署投影。
 - Target 目录是生成输出，不是事实源。
 - macOS 桌面端依赖 CLI bridge 协议，不另建第二套状态模型。
-- GitHub tree URL 的 branch/path 边界通过远端分支确认；无法确认时明确失败，不按路径片段猜测。
-- Managed update 只读写 `~/.skillflow/source/<kind>/<sourceId>` 的规范 checkout；lock 路径不匹配时拒绝更新。
+- Managed update 只读写 `~/.skillflow/source/<kind>/<sourceId>` 的规范 checkout；lock 路径不匹配或 checkout 路径链包含符号链接时拒绝更新。
 - 桌面端更新始终有界：每个明确选择的 source 预算 5 分钟，总上限 15 分钟；全部更新使用 15 分钟。
 
 ## 非目标

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -52,6 +52,12 @@ save-settings
 
 Bridge changes are external changes. Update parser tests, CLI bridge behavior, desktop bridge models, and release/user docs when changing this surface.
 
+Desktop helper execution is always time-bounded. Ordinary commands use 60
+seconds, import/add commands use 5 minutes, and managed update scales by the
+number of explicitly selected sources at 5 minutes each with a 15-minute
+ceiling. Update-all uses the 15-minute ceiling. These budgets are desktop
+process behavior and do not change the protocol payload shape.
+
 When adding, removing, or renaming a bridge command:
 
 1. Update `BRIDGE_COMMAND_NAMES` in `packages/shared-types/src/protocol.ts`.

--- a/docs/superpowers/specs/2026-06-03-import-timeout-and-feedback-design.md
+++ b/docs/superpowers/specs/2026-06-03-import-timeout-and-feedback-design.md
@@ -39,9 +39,15 @@ The Import page seeds recommended cards from bundled `recommendations.json`. Car
 
 ### Bridge Timeout
 
-Add a fixed timeout to `BridgeClient.send`, with a default of 60 seconds. If the helper process has not exited by then, terminate it, clear pipe handlers, and throw `BridgeClientError.timeout(timeoutMs)`.
+Add a bounded timeout to `BridgeClient.send`. Ordinary commands use 60 seconds,
+network-heavy import/add commands use 5 minutes, and managed update uses 5
+minutes per explicitly selected source with a 15-minute ceiling. Update-all
+uses the 15-minute ceiling. If the helper process has not exited by its active
+budget, terminate it, clear pipe handlers, and throw
+`BridgeClientError.timeout(timeoutMs)`.
 
-The timeout should cover all bridge commands. This is acceptable because desktop actions should not wait indefinitely. Long commands can later receive command-specific budgets if needed.
+The timeout must cover all bridge commands. Command-specific budgets may be
+longer than the ordinary default, but no desktop action may wait indefinitely.
 
 Implementation detail:
 
@@ -112,7 +118,7 @@ If the Swift test harness cannot easily spawn a hanging helper, cover bridge tim
 
 ## Risks
 
-- A 60 second bridge timeout can interrupt a legitimately slow import on poor networks. This is acceptable for desktop UX because indefinite loading is worse, and the user can retry.
+- A bounded bridge timeout can interrupt a legitimately slow network action. Import and update receive larger command-specific budgets, while indefinite loading remains disallowed.
 - Timeout behavior in Swift subprocess handling must avoid leaving pipe readability handlers attached.
 - Adding a fetch helper touches shared integration code. Keep the helper small and avoid broad refactors.
 

--- a/docs/superpowers/specs/2026-08-18-git-source-update-boundaries-design.md
+++ b/docs/superpowers/specs/2026-08-18-git-source-update-boundaries-design.md
@@ -10,12 +10,13 @@ or desktop process boundaries documented by the upstream architecture.
 This change is limited to managed source update behavior:
 
 - preserve the remote-ref precheck and reuse an existing managed Git object store;
-- resolve GitHub tree URLs against confirmed remote branch names;
-- reject update when a managed lock points outside its canonical checkout path;
+- preserve an already-recorded `originBranch` throughout the update;
+- reject update when a managed lock points outside its canonical checkout path
+  or that path uses symbolic links;
 - keep every desktop bridge update bounded.
 
-It does not expand GitLab tree URL behavior and does not change reconcile,
-repair, deployment, or external-source lifecycle rules.
+It does not change GitHub or GitLab locator parsing, reconcile, repair,
+deployment, or external-source lifecycle rules.
 
 ## Contracts
 
@@ -28,24 +29,30 @@ lock path must equal:
 <stateRoot>/source/<sourceKind>/<sourceId>
 ```
 
-The resolved path must also remain inside `<stateRoot>/source`. A mismatch
-returns `SOURCE_CHECKOUT_PATH_INVALID` without reading or modifying that path.
-External sources continue to leave the managed update path before this check.
+The resolved path must also remain inside `<stateRoot>/source`. The managed
+path components must not be symbolic links, and their real paths must remain
+under the real source root. A mismatch returns
+`SOURCE_CHECKOUT_PATH_INVALID` without reading or modifying the referenced
+checkout. External sources continue to leave the managed update path before
+this check.
 
-### GitHub tree URLs
+### Git update path
 
-The text after `/tree/` is ambiguous when branch names contain `/`. Resolve it
-by generating branch/path splits from longest branch candidate to shortest:
+When a lock has an `originBranch`, remote precheck, local-object fetch, clean
+clone, and archive fallback use that exact branch. Failure must not silently
+switch to `main` or `master`. Locks without `originBranch` retain the upstream
+default-branch behavior.
 
-1. If Git is available, compare candidates with `git ls-remote --heads`.
-2. Otherwise, or when the Git probe fails, confirm candidates through the
-   GitHub branch API.
-3. Use the longest confirmed branch and keep the remaining suffix as the
-   requested repository path.
-4. If no branch is confirmed, fail clearly instead of guessing.
+For a managed Git checkout, first attempt a local no-checkout clone to reuse
+its object store, then fetch the remote ref and detach at `FETCH_HEAD`. If this
+optimization fails, remove the temporary checkout and use the upstream clean
+clone, HTTPS fallback, and archive fallback sequence.
 
-The confirmed branch is stored as `originBranch` and reused by precheck,
-clone, fetch, and archive fallback.
+### Mutation lock ownership
+
+A lock with a live PID is never reclaimed solely because its timestamp has
+crossed the stale threshold. A dead owner may be reclaimed immediately, while
+missing or unreadable ownership metadata retains the upstream age-based rule.
 
 ### Desktop update budget
 
@@ -62,13 +69,15 @@ the same as other bridge commands.
 
 ## Acceptance tests
 
-1. A GitHub tree URL whose branch is `feature/foo` resolves that complete
-   branch and preserves the remaining skill path.
-2. GitHub API fallback provides the same resolution when Git is unavailable.
-3. An unresolvable tree branch fails instead of using the first path segment.
-4. Managed update rejects a mismatched `lock.localPath` before checkout
-   preparation and leaves the referenced directory untouched.
-5. One- and two-source desktop updates receive 5- and 10-minute budgets, while
+1. An unchanged remote commit skips checkout preparation.
+2. A changed Git source reuses the existing managed object store.
+3. A failed local reuse falls back to the upstream clean-fetch sequence.
+4. A recorded `originBranch` is used by every update fetch path without
+   switching to a default branch.
+5. Managed update rejects mismatched and symbolic-link checkout paths before
+   checkout preparation and leaves referenced external directories untouched.
+6. A live process lock is not reclaimed after five minutes.
+7. One- and two-source desktop updates receive 5- and 10-minute budgets, while
    update-all and larger selections never exceed 15 minutes.
-6. External sources remain excluded from managed update before any checkout
+8. External sources remain excluded from managed update before any checkout
    operation.

--- a/docs/superpowers/specs/2026-08-18-git-source-update-boundaries-design.md
+++ b/docs/superpowers/specs/2026-08-18-git-source-update-boundaries-design.md
@@ -1,0 +1,74 @@
+# Git Source Update Boundaries Design
+
+## Goal
+
+Make managed source updates faster without weakening the ownership, locator,
+or desktop process boundaries documented by the upstream architecture.
+
+## Scope
+
+This change is limited to managed source update behavior:
+
+- preserve the remote-ref precheck and reuse an existing managed Git object store;
+- resolve GitHub tree URLs against confirmed remote branch names;
+- reject update when a managed lock points outside its canonical checkout path;
+- keep every desktop bridge update bounded.
+
+It does not expand GitLab tree URL behavior and does not change reconcile,
+repair, deployment, or external-source lifecycle rules.
+
+## Contracts
+
+### Managed checkout ownership
+
+Before any update preflight, checkout reuse, rename, or replacement, a managed
+lock path must equal:
+
+```text
+<stateRoot>/source/<sourceKind>/<sourceId>
+```
+
+The resolved path must also remain inside `<stateRoot>/source`. A mismatch
+returns `SOURCE_CHECKOUT_PATH_INVALID` without reading or modifying that path.
+External sources continue to leave the managed update path before this check.
+
+### GitHub tree URLs
+
+The text after `/tree/` is ambiguous when branch names contain `/`. Resolve it
+by generating branch/path splits from longest branch candidate to shortest:
+
+1. If Git is available, compare candidates with `git ls-remote --heads`.
+2. Otherwise, or when the Git probe fails, confirm candidates through the
+   GitHub branch API.
+3. Use the longest confirmed branch and keep the remaining suffix as the
+   requested repository path.
+4. If no branch is confirmed, fail clearly instead of guessing.
+
+The confirmed branch is stored as `originBranch` and reused by precheck,
+clone, fetch, and archive fallback.
+
+### Desktop update budget
+
+Every bridge command remains time-bounded. Managed update uses a dedicated
+budget based on the distinct selected source count:
+
+- one source: 5 minutes;
+- two sources: 10 minutes;
+- three or more sources: 15 minutes;
+- update all: 15 minutes.
+
+Tests may inject shorter budgets. Timeout termination and output handling stay
+the same as other bridge commands.
+
+## Acceptance tests
+
+1. A GitHub tree URL whose branch is `feature/foo` resolves that complete
+   branch and preserves the remaining skill path.
+2. GitHub API fallback provides the same resolution when Git is unavailable.
+3. An unresolvable tree branch fails instead of using the first path segment.
+4. Managed update rejects a mismatched `lock.localPath` before checkout
+   preparation and leaves the referenced directory untouched.
+5. One- and two-source desktop updates receive 5- and 10-minute budgets, while
+   update-all and larger selections never exceed 15 minutes.
+6. External sources remain excluded from managed update before any checkout
+   operation.

--- a/packages/core-engine/src/services/source-authority-service.ts
+++ b/packages/core-engine/src/services/source-authority-service.ts
@@ -503,30 +503,40 @@ export class SourceAuthorityService {
     }
 
     const kindRoot = path.dirname(expectedCheckoutPath);
-    for (const managedPath of [sourceRoot, kindRoot]) {
+    const existingManagedPaths = new Set<string>();
+    for (const managedPath of [sourceRoot, kindRoot, expectedCheckoutPath]) {
       try {
-        if ((await fs.lstat(managedPath)).isSymbolicLink()) {
+        const stats = await fs.lstat(managedPath);
+        if (stats.isSymbolicLink()) {
           return false;
         }
-      } catch {
-        return false;
+        existingManagedPaths.add(managedPath);
+      } catch (error) {
+        if (
+          typeof error !== "object"
+          || error === null
+          || !("code" in error)
+          || error.code !== "ENOENT"
+        ) {
+          return false;
+        }
       }
     }
 
-    const checkoutExists = await pathExists(expectedCheckoutPath);
-    if (checkoutExists) {
-      try {
-        if ((await fs.lstat(expectedCheckoutPath)).isSymbolicLink()) {
-          return false;
-        }
-      } catch {
-        return false;
-      }
-    }
+    const sourceRootExists = existingManagedPaths.has(sourceRoot);
+    const kindRootExists = existingManagedPaths.has(kindRoot);
+    const checkoutExists = existingManagedPaths.has(expectedCheckoutPath);
 
     try {
-      const realSourceRoot = await fs.realpath(sourceRoot);
-      const realKindRoot = await fs.realpath(kindRoot);
+      const realSourceRoot = sourceRootExists
+        ? await fs.realpath(sourceRoot)
+        : path.join(
+            await fs.realpath(path.dirname(sourceRoot)),
+            path.basename(sourceRoot),
+          );
+      const realKindRoot = kindRootExists
+        ? await fs.realpath(kindRoot)
+        : path.join(realSourceRoot, path.basename(kindRoot));
       if (!isPathInside(realSourceRoot, realKindRoot)) {
         return false;
       }

--- a/packages/core-engine/src/services/source-authority-service.ts
+++ b/packages/core-engine/src/services/source-authority-service.ts
@@ -329,14 +329,14 @@ export class SourceAuthorityService {
 
       const sourceRoot = path.join(this.options.stateStore.rootPath, "source");
       const expectedCheckoutPath = path.join(sourceRoot, source.kind, sourceId);
-      const normalizedLocalPath = path.resolve(lock.localPath);
-      if (
-        normalizedLocalPath !== path.resolve(expectedCheckoutPath)
-        || !isPathInside(sourceRoot, normalizedLocalPath)
-      ) {
+      if (!await this.isManagedCheckoutPathValid(
+        sourceRoot,
+        expectedCheckoutPath,
+        lock.localPath,
+      )) {
         return fail({
           code: "SOURCE_CHECKOUT_PATH_INVALID",
-          message: `Refusing to update checkout with mismatched managed path: ${lock.localPath}`,
+          message: `Refusing to update checkout with invalid managed path: ${lock.localPath}`,
         }, warnings);
       }
 
@@ -392,6 +392,7 @@ export class SourceAuthorityService {
         },
         checkoutPath: tempCheckoutPath,
         existingCheckoutPath: lock.localPath,
+        ...(lock.originBranch ? { updateBranch: lock.originBranch } : {}),
         allowEmptyLeafs: true,
       });
       if (!prepared.ok) {
@@ -486,6 +487,56 @@ export class SourceAuthorityService {
       ...(failed.length > 0 ? { failed } : {}),
       ...(precheckFallbackSourceIds.length > 0 ? { precheckFallbackSourceIds } : {}),
     }, warnings);
+  }
+
+  private async isManagedCheckoutPathValid(
+    sourceRoot: string,
+    expectedCheckoutPath: string,
+    localPath: string,
+  ): Promise<boolean> {
+    const normalizedLocalPath = path.resolve(localPath);
+    if (
+      normalizedLocalPath !== path.resolve(expectedCheckoutPath)
+      || !isPathInside(sourceRoot, normalizedLocalPath)
+    ) {
+      return false;
+    }
+
+    const kindRoot = path.dirname(expectedCheckoutPath);
+    for (const managedPath of [sourceRoot, kindRoot]) {
+      try {
+        if ((await fs.lstat(managedPath)).isSymbolicLink()) {
+          return false;
+        }
+      } catch {
+        return false;
+      }
+    }
+
+    const checkoutExists = await pathExists(expectedCheckoutPath);
+    if (checkoutExists) {
+      try {
+        if ((await fs.lstat(expectedCheckoutPath)).isSymbolicLink()) {
+          return false;
+        }
+      } catch {
+        return false;
+      }
+    }
+
+    try {
+      const realSourceRoot = await fs.realpath(sourceRoot);
+      const realKindRoot = await fs.realpath(kindRoot);
+      if (!isPathInside(realSourceRoot, realKindRoot)) {
+        return false;
+      }
+      if (!checkoutExists) {
+        return true;
+      }
+      return isPathInside(realSourceRoot, await fs.realpath(expectedCheckoutPath));
+    } catch {
+      return false;
+    }
   }
 
   async reconcileInventory(

--- a/packages/core-engine/src/services/source-authority-service.ts
+++ b/packages/core-engine/src/services/source-authority-service.ts
@@ -333,6 +333,7 @@ export class SourceAuthorityService {
         try {
           const remoteCommit = await this.options.checkoutService.readGitRemoteHeadCommit(
             source.locator,
+            lock.originBranch ? { branch: lock.originBranch } : {},
           );
           if (!remoteCommit) {
             precheckFallbackSourceIds.push(sourceId);
@@ -374,8 +375,10 @@ export class SourceAuthorityService {
         options: {
           sourceIdOverride: sourceId,
           displayNameOverride: source.displayName,
+          ...(lock.originBranch ? { originBranch: lock.originBranch } : {}),
         },
         checkoutPath: tempCheckoutPath,
+        existingCheckoutPath: lock.localPath,
         allowEmptyLeafs: true,
       });
       if (!prepared.ok) {

--- a/packages/core-engine/src/services/source-authority-service.ts
+++ b/packages/core-engine/src/services/source-authority-service.ts
@@ -327,6 +327,19 @@ export class SourceAuthorityService {
         continue;
       }
 
+      const sourceRoot = path.join(this.options.stateStore.rootPath, "source");
+      const expectedCheckoutPath = path.join(sourceRoot, source.kind, sourceId);
+      const normalizedLocalPath = path.resolve(lock.localPath);
+      if (
+        normalizedLocalPath !== path.resolve(expectedCheckoutPath)
+        || !isPathInside(sourceRoot, normalizedLocalPath)
+      ) {
+        return fail({
+          code: "SOURCE_CHECKOUT_PATH_INVALID",
+          message: `Refusing to update checkout with mismatched managed path: ${lock.localPath}`,
+        }, warnings);
+      }
+
       const lockedCommit = this.readLockedCommitSha(lock.revision);
       let repairReason: SourceRepairReason | undefined;
       if (source.kind === "git" && lockedCommit) {

--- a/packages/core-engine/src/services/source-checkout-service.ts
+++ b/packages/core-engine/src/services/source-checkout-service.ts
@@ -26,6 +26,7 @@ import {
   fetchWithTimeout,
   withNetworkRetries,
 } from "@skill-flow/integration/utils/fetch-timeout";
+import { resolveGitHubTreePath } from "@skill-flow/integration/utils/github-catalog";
 import { git, isGitAvailable } from "@skill-flow/integration/utils/git";
 import { parseGitHubRepo, parseHostedGitRepo } from "@skill-flow/integration/utils/naming";
 import { fail, ok } from "@skill-flow/integration/utils/result";
@@ -325,7 +326,7 @@ export class SourceCheckoutService {
       };
     }
 
-    const treeLocator = this.parseTreeLocator(trimmed);
+    const treeLocator = await this.parseTreeLocator(trimmed);
     if (treeLocator) {
       const requestedPath = this.joinRequestedPaths(
         treeLocator.requestedPath,
@@ -727,52 +728,55 @@ export class SourceCheckoutService {
     return "git";
   }
 
-  private parseTreeLocator(
+  private async parseTreeLocator(
     locator: string,
-  ): { repoLocator: string; requestedPath?: string; originBranch?: string } | null {
+  ): Promise<{ repoLocator: string; requestedPath?: string; originBranch?: string } | null> {
+    let url: URL;
     try {
-      const url = new URL(locator);
-
-      const parts = url.pathname.split("/").filter(Boolean);
-      if (url.hostname === "github.com") {
-        if (parts.length < 5 || parts[2] !== "tree") {
-          return null;
-        }
-
-        const owner = parts[0];
-        const repo = parts[1];
-        const originBranch = parts[3];
-        const requestedPath = parts.slice(4).join("/");
-        if (!owner || !repo || !originBranch || !requestedPath) {
-          return null;
-        }
-
-        return {
-          repoLocator: `https://github.com/${owner}/${repo}.git`,
-          requestedPath,
-          originBranch,
-        };
-      }
-
-      if (url.hostname === "gitlab.com") {
-        const markerIndex = parts.findIndex(
-          (segment, index) => segment === "-" && parts[index + 1] === "tree",
-        );
-        if (markerIndex < 2) {
-          return null;
-        }
-
-        const originBranch = parts[markerIndex + 2];
-        const requestedPath = parts.slice(markerIndex + 3).join("/");
-
-        return {
-          repoLocator: `https://gitlab.com/${parts.slice(0, markerIndex).join("/")}.git`,
-          ...(requestedPath ? { requestedPath } : {}),
-          ...(originBranch ? { originBranch } : {}),
-        };
-      }
+      url = new URL(locator);
     } catch {
       return null;
+    }
+
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (url.hostname === "github.com") {
+      if (parts.length < 5 || parts[2] !== "tree") {
+        return null;
+      }
+
+      const owner = parts[0];
+      const repo = parts[1];
+      const treePath = parts.slice(3).join("/");
+      if (!owner || !repo || !treePath) {
+        return null;
+      }
+
+      const repoLocator = `https://github.com/${owner}/${repo}.git`;
+      const resolvedTreePath = await resolveGitHubTreePath(repoLocator, treePath);
+
+      return {
+        repoLocator,
+        requestedPath: resolvedTreePath.requestedPath,
+        originBranch: resolvedTreePath.branch,
+      };
+    }
+
+    if (url.hostname === "gitlab.com") {
+      const markerIndex = parts.findIndex(
+        (segment, index) => segment === "-" && parts[index + 1] === "tree",
+      );
+      if (markerIndex < 2) {
+        return null;
+      }
+
+      const originBranch = parts[markerIndex + 2];
+      const requestedPath = parts.slice(markerIndex + 3).join("/");
+
+      return {
+        repoLocator: `https://gitlab.com/${parts.slice(0, markerIndex).join("/")}.git`,
+        ...(requestedPath ? { requestedPath } : {}),
+        ...(originBranch ? { originBranch } : {}),
+      };
     }
 
     return null;

--- a/packages/core-engine/src/services/source-checkout-service.ts
+++ b/packages/core-engine/src/services/source-checkout-service.ts
@@ -97,6 +97,7 @@ type SourceResolution = {
   clawhubSlug?: string;
   requestedVersion?: string;
   versionMode?: "pinned" | "floating";
+  originBranch?: string;
 };
 
 export class SourceCheckoutService {
@@ -154,6 +155,7 @@ export class SourceCheckoutService {
       options?: AddSourceOptions;
       existingSources?: Array<{ id: string; kind?: SourceKind; locator: string; displayName: string }>;
       checkoutPath?: string;
+      existingCheckoutPath?: string;
       suffix?: string;
       allowEmptyLeafs?: boolean;
     } = {},
@@ -171,7 +173,7 @@ export class SourceCheckoutService {
     await ensureDir(path.dirname(checkoutPath));
 
     try {
-      await this.fetchSource(resolved, checkoutPath);
+      await this.fetchSource(resolved, checkoutPath, input.existingCheckoutPath);
     } catch (error) {
       await removePath(checkoutPath);
       return fail({
@@ -187,7 +189,9 @@ export class SourceCheckoutService {
       resolved.displayName,
       checkoutPath,
       resolved.requestedPath,
-      options,
+      resolved.originBranch && !options.originBranch
+        ? { ...options, originBranch: resolved.originBranch }
+        : options,
       input.allowEmptyLeafs === undefined ? {} : { allowEmptyLeafs: input.allowEmptyLeafs },
     );
     if (!snapshot.ok) {
@@ -256,10 +260,15 @@ export class SourceCheckoutService {
     }, snapshot.warnings);
   }
 
-  async readGitRemoteHeadCommit(locator: string): Promise<string | undefined> {
+  async readGitRemoteHeadCommit(
+    locator: string,
+    options: { branch?: string } = {},
+  ): Promise<string | undefined> {
     if (!(await isGitAvailable())) {
       return undefined;
     }
+
+    const gitLocator = await this.normalizeLocator(locator);
 
     const parseCommitSha = (raw: string): string | undefined => {
       const line = raw
@@ -270,7 +279,8 @@ export class SourceCheckoutService {
       return sha && /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(sha) ? sha : undefined;
     };
 
-    const headOutput = await git(["ls-remote", locator, "HEAD"], { timeoutMs: 5_000 });
+    const remoteRef = this.remoteRef(options.branch);
+    const headOutput = await git(["ls-remote", gitLocator, remoteRef], { timeoutMs: 5_000 });
     return parseCommitSha(headOutput);
   }
 
@@ -328,6 +338,7 @@ export class SourceCheckoutService {
         displayName: options.displayNameOverride ?? deriveDisplayName(treeLocator.repoLocator),
         sourceId: options.sourceIdOverride ?? deriveSourceId(treeLocator.repoLocator),
         ...(requestedPath ? { requestedPath } : {}),
+        ...(treeLocator.originBranch ? { originBranch: treeLocator.originBranch } : {}),
       };
     }
 
@@ -344,6 +355,7 @@ export class SourceCheckoutService {
         displayName: options.displayNameOverride ?? deriveDisplayName(shorthandLocator.repoLocator),
         sourceId: options.sourceIdOverride ?? deriveSourceId(shorthandLocator.repoLocator),
         ...(requestedPath ? { requestedPath } : {}),
+        ...(options.originBranch ? { originBranch: options.originBranch } : {}),
       };
     }
 
@@ -376,6 +388,7 @@ export class SourceCheckoutService {
       displayName: options.displayNameOverride ?? deriveDisplayName(locator),
       sourceId: options.sourceIdOverride ?? deriveSourceId(locator),
       ...(requestedPath ? { requestedPath } : {}),
+      ...(options.originBranch ? { originBranch: options.originBranch } : {}),
     };
   }
 
@@ -463,6 +476,7 @@ export class SourceCheckoutService {
   private async fetchSource(
     source: SourceResolution,
     checkoutPath: string,
+    existingCheckoutPath?: string,
   ): Promise<void> {
     if (source.kind === "local") {
       await copyDirectory(source.localPath!, checkoutPath);
@@ -470,7 +484,23 @@ export class SourceCheckoutService {
     }
 
     if (source.kind === "git") {
-      await this.fetchGitSource(source.gitLocator!, checkoutPath);
+      if (
+        existingCheckoutPath
+        && await this.isGitRepositoryPath(existingCheckoutPath)
+      ) {
+        try {
+          await this.refreshGitSourceFromExisting(
+            source.gitLocator!,
+            existingCheckoutPath,
+            checkoutPath,
+            source.originBranch,
+          );
+          return;
+        } catch {
+          await removePath(checkoutPath).catch(() => {});
+        }
+      }
+      await this.fetchGitSource(source.gitLocator!, checkoutPath, source.originBranch);
       return;
     }
 
@@ -483,6 +513,31 @@ export class SourceCheckoutService {
     } finally {
       await removePath(installed.workdir);
     }
+  }
+
+  private async refreshGitSourceFromExisting(
+    locator: string,
+    existingCheckoutPath: string,
+    checkoutPath: string,
+    originBranch?: string,
+  ): Promise<void> {
+    await removePath(checkoutPath).catch(() => {});
+    await git([
+      "clone",
+      "--local",
+      "--no-checkout",
+      existingCheckoutPath,
+      checkoutPath,
+    ]);
+    await git(["remote", "set-url", "origin", locator], { cwd: checkoutPath });
+    const remoteRef = this.remoteRef(originBranch);
+    await git(["fetch", "--depth", "1", "origin", remoteRef], { cwd: checkoutPath });
+    await git(["checkout", "--detach", "--force", "FETCH_HEAD"], { cwd: checkoutPath });
+  }
+
+  private remoteRef(originBranch?: string): string {
+    const branch = originBranch?.trim();
+    return branch ? `refs/heads/${branch}` : "HEAD";
   }
 
   private async buildSnapshot(
@@ -674,7 +729,7 @@ export class SourceCheckoutService {
 
   private parseTreeLocator(
     locator: string,
-  ): { repoLocator: string; requestedPath?: string } | null {
+  ): { repoLocator: string; requestedPath?: string; originBranch?: string } | null {
     try {
       const url = new URL(locator);
 
@@ -686,14 +741,16 @@ export class SourceCheckoutService {
 
         const owner = parts[0];
         const repo = parts[1];
+        const originBranch = parts[3];
         const requestedPath = parts.slice(4).join("/");
-        if (!owner || !repo || !requestedPath) {
+        if (!owner || !repo || !originBranch || !requestedPath) {
           return null;
         }
 
         return {
           repoLocator: `https://github.com/${owner}/${repo}.git`,
           requestedPath,
+          originBranch,
         };
       }
 
@@ -705,11 +762,13 @@ export class SourceCheckoutService {
           return null;
         }
 
+        const originBranch = parts[markerIndex + 2];
         const requestedPath = parts.slice(markerIndex + 3).join("/");
 
         return {
           repoLocator: `https://gitlab.com/${parts.slice(0, markerIndex).join("/")}.git`,
           ...(requestedPath ? { requestedPath } : {}),
+          ...(originBranch ? { originBranch } : {}),
         };
       }
     } catch {
@@ -802,14 +861,18 @@ export class SourceCheckoutService {
     return `${normalizedBase}/${normalizedChild}`;
   }
 
-  private async fetchGitSource(locator: string, checkoutPath: string): Promise<void> {
+  private async fetchGitSource(
+    locator: string,
+    checkoutPath: string,
+    originBranch?: string,
+  ): Promise<void> {
     if (!(await isGitAvailable())) {
-      await this.fetchGitArchive(locator, checkoutPath);
+      await this.fetchGitArchive(locator, checkoutPath, originBranch);
       return;
     }
 
     try {
-      await this.cloneGitWithRetries(locator, checkoutPath);
+      await this.cloneGitWithRetries(locator, checkoutPath, originBranch);
       return;
     } catch {
       // Prefer HTTPS fallback when SSH/clone URL variants fail, then archive.
@@ -818,23 +881,34 @@ export class SourceCheckoutService {
     const fallbackLocator = this.resolveGitCloneFallbackLocator(locator);
     if (fallbackLocator) {
       try {
-        await this.cloneGitWithRetries(fallbackLocator, checkoutPath);
+        await this.cloneGitWithRetries(fallbackLocator, checkoutPath, originBranch);
         return;
       } catch {
         await removePath(checkoutPath);
-        await this.fetchGitArchive(fallbackLocator, checkoutPath);
+        await this.fetchGitArchive(fallbackLocator, checkoutPath, originBranch);
         return;
       }
     }
 
     await removePath(checkoutPath);
-    await this.fetchGitArchive(locator, checkoutPath);
+    await this.fetchGitArchive(locator, checkoutPath, originBranch);
   }
 
-  private async cloneGitWithRetries(locator: string, checkoutPath: string): Promise<void> {
+  private async cloneGitWithRetries(
+    locator: string,
+    checkoutPath: string,
+    originBranch?: string,
+  ): Promise<void> {
     await withNetworkRetries(async () => {
       await removePath(checkoutPath).catch(() => {});
-      await git(["clone", "--depth", "1", locator, checkoutPath]);
+      await git([
+        "clone",
+        "--depth",
+        "1",
+        ...(originBranch ? ["--branch", originBranch] : []),
+        locator,
+        checkoutPath,
+      ]);
     }, { attempts: 2 });
   }
 
@@ -855,11 +929,9 @@ export class SourceCheckoutService {
     try {
       await ensureDir(tempRoot);
 
-      const branchCandidates = [
-        preferredBranch,
-        "main",
-        "master",
-      ].filter((value, index, values): value is string => Boolean(value) && values.indexOf(value) === index);
+      const branchCandidates = preferredBranch
+        ? [preferredBranch]
+        : ["main", "master"];
 
       let lastError: Error | undefined;
       for (const branch of branchCandidates) {

--- a/packages/core-engine/src/services/source-checkout-service.ts
+++ b/packages/core-engine/src/services/source-checkout-service.ts
@@ -26,7 +26,6 @@ import {
   fetchWithTimeout,
   withNetworkRetries,
 } from "@skill-flow/integration/utils/fetch-timeout";
-import { resolveGitHubTreePath } from "@skill-flow/integration/utils/github-catalog";
 import { git, isGitAvailable } from "@skill-flow/integration/utils/git";
 import { parseGitHubRepo, parseHostedGitRepo } from "@skill-flow/integration/utils/naming";
 import { fail, ok } from "@skill-flow/integration/utils/result";
@@ -98,7 +97,6 @@ type SourceResolution = {
   clawhubSlug?: string;
   requestedVersion?: string;
   versionMode?: "pinned" | "floating";
-  originBranch?: string;
 };
 
 export class SourceCheckoutService {
@@ -157,6 +155,7 @@ export class SourceCheckoutService {
       existingSources?: Array<{ id: string; kind?: SourceKind; locator: string; displayName: string }>;
       checkoutPath?: string;
       existingCheckoutPath?: string;
+      updateBranch?: string;
       suffix?: string;
       allowEmptyLeafs?: boolean;
     } = {},
@@ -174,7 +173,12 @@ export class SourceCheckoutService {
     await ensureDir(path.dirname(checkoutPath));
 
     try {
-      await this.fetchSource(resolved, checkoutPath, input.existingCheckoutPath);
+      await this.fetchSource(
+        resolved,
+        checkoutPath,
+        input.existingCheckoutPath,
+        input.updateBranch,
+      );
     } catch (error) {
       await removePath(checkoutPath);
       return fail({
@@ -190,9 +194,7 @@ export class SourceCheckoutService {
       resolved.displayName,
       checkoutPath,
       resolved.requestedPath,
-      resolved.originBranch && !options.originBranch
-        ? { ...options, originBranch: resolved.originBranch }
-        : options,
+      options,
       input.allowEmptyLeafs === undefined ? {} : { allowEmptyLeafs: input.allowEmptyLeafs },
     );
     if (!snapshot.ok) {
@@ -326,7 +328,7 @@ export class SourceCheckoutService {
       };
     }
 
-    const treeLocator = await this.parseTreeLocator(trimmed);
+    const treeLocator = this.parseTreeLocator(trimmed);
     if (treeLocator) {
       const requestedPath = this.joinRequestedPaths(
         treeLocator.requestedPath,
@@ -339,7 +341,6 @@ export class SourceCheckoutService {
         displayName: options.displayNameOverride ?? deriveDisplayName(treeLocator.repoLocator),
         sourceId: options.sourceIdOverride ?? deriveSourceId(treeLocator.repoLocator),
         ...(requestedPath ? { requestedPath } : {}),
-        ...(treeLocator.originBranch ? { originBranch: treeLocator.originBranch } : {}),
       };
     }
 
@@ -356,7 +357,6 @@ export class SourceCheckoutService {
         displayName: options.displayNameOverride ?? deriveDisplayName(shorthandLocator.repoLocator),
         sourceId: options.sourceIdOverride ?? deriveSourceId(shorthandLocator.repoLocator),
         ...(requestedPath ? { requestedPath } : {}),
-        ...(options.originBranch ? { originBranch: options.originBranch } : {}),
       };
     }
 
@@ -389,7 +389,6 @@ export class SourceCheckoutService {
       displayName: options.displayNameOverride ?? deriveDisplayName(locator),
       sourceId: options.sourceIdOverride ?? deriveSourceId(locator),
       ...(requestedPath ? { requestedPath } : {}),
-      ...(options.originBranch ? { originBranch: options.originBranch } : {}),
     };
   }
 
@@ -478,6 +477,7 @@ export class SourceCheckoutService {
     source: SourceResolution,
     checkoutPath: string,
     existingCheckoutPath?: string,
+    updateBranch?: string,
   ): Promise<void> {
     if (source.kind === "local") {
       await copyDirectory(source.localPath!, checkoutPath);
@@ -494,14 +494,14 @@ export class SourceCheckoutService {
             source.gitLocator!,
             existingCheckoutPath,
             checkoutPath,
-            source.originBranch,
+            updateBranch,
           );
           return;
         } catch {
           await removePath(checkoutPath).catch(() => {});
         }
       }
-      await this.fetchGitSource(source.gitLocator!, checkoutPath, source.originBranch);
+      await this.fetchGitSource(source.gitLocator!, checkoutPath, updateBranch);
       return;
     }
 
@@ -728,55 +728,48 @@ export class SourceCheckoutService {
     return "git";
   }
 
-  private async parseTreeLocator(
+  private parseTreeLocator(
     locator: string,
-  ): Promise<{ repoLocator: string; requestedPath?: string; originBranch?: string } | null> {
-    let url: URL;
+  ): { repoLocator: string; requestedPath?: string } | null {
     try {
-      url = new URL(locator);
+      const url = new URL(locator);
+
+      const parts = url.pathname.split("/").filter(Boolean);
+      if (url.hostname === "github.com") {
+        if (parts.length < 5 || parts[2] !== "tree") {
+          return null;
+        }
+
+        const owner = parts[0];
+        const repo = parts[1];
+        const requestedPath = parts.slice(4).join("/");
+        if (!owner || !repo || !requestedPath) {
+          return null;
+        }
+
+        return {
+          repoLocator: `https://github.com/${owner}/${repo}.git`,
+          requestedPath,
+        };
+      }
+
+      if (url.hostname === "gitlab.com") {
+        const markerIndex = parts.findIndex(
+          (segment, index) => segment === "-" && parts[index + 1] === "tree",
+        );
+        if (markerIndex < 2) {
+          return null;
+        }
+
+        const requestedPath = parts.slice(markerIndex + 3).join("/");
+
+        return {
+          repoLocator: `https://gitlab.com/${parts.slice(0, markerIndex).join("/")}.git`,
+          ...(requestedPath ? { requestedPath } : {}),
+        };
+      }
     } catch {
       return null;
-    }
-
-    const parts = url.pathname.split("/").filter(Boolean);
-    if (url.hostname === "github.com") {
-      if (parts.length < 5 || parts[2] !== "tree") {
-        return null;
-      }
-
-      const owner = parts[0];
-      const repo = parts[1];
-      const treePath = parts.slice(3).join("/");
-      if (!owner || !repo || !treePath) {
-        return null;
-      }
-
-      const repoLocator = `https://github.com/${owner}/${repo}.git`;
-      const resolvedTreePath = await resolveGitHubTreePath(repoLocator, treePath);
-
-      return {
-        repoLocator,
-        requestedPath: resolvedTreePath.requestedPath,
-        originBranch: resolvedTreePath.branch,
-      };
-    }
-
-    if (url.hostname === "gitlab.com") {
-      const markerIndex = parts.findIndex(
-        (segment, index) => segment === "-" && parts[index + 1] === "tree",
-      );
-      if (markerIndex < 2) {
-        return null;
-      }
-
-      const originBranch = parts[markerIndex + 2];
-      const requestedPath = parts.slice(markerIndex + 3).join("/");
-
-      return {
-        repoLocator: `https://gitlab.com/${parts.slice(0, markerIndex).join("/")}.git`,
-        ...(requestedPath ? { requestedPath } : {}),
-        ...(originBranch ? { originBranch } : {}),
-      };
     }
 
     return null;
@@ -913,6 +906,16 @@ export class SourceCheckoutService {
         locator,
         checkoutPath,
       ]);
+      if (originBranch) {
+        await git(
+          ["fetch", "--depth", "1", "origin", this.remoteRef(originBranch)],
+          { cwd: checkoutPath },
+        );
+        await git(
+          ["checkout", "--detach", "--force", "FETCH_HEAD"],
+          { cwd: checkoutPath },
+        );
+      }
     }, { attempts: 2 });
   }
 

--- a/packages/core-engine/src/tests/source-authority-service.test.ts
+++ b/packages/core-engine/src/tests/source-authority-service.test.ts
@@ -217,6 +217,45 @@ describe.sequential("SourceAuthorityService", () => {
     ]);
   });
 
+  test("refuses to update a source whose checkout path does not match its v2 identity", async () => {
+    const repoPath = await createRepo(sandbox.sandboxRoot, {
+      "skills/one/SKILL.md": skillDoc("one", "One."),
+    });
+    const externalPath = path.join(sandbox.sandboxRoot, "external-checkout");
+    await fs.mkdir(externalPath, { recursive: true });
+    await fs.writeFile(path.join(externalPath, "sentinel.txt"), "keep", "utf8");
+    const stateStore = new StateStore(sandbox.stateRoot);
+    await stateStore.init();
+    const checkoutService = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+    const service = new SourceAuthorityService({ stateStore, checkoutService });
+    const added = await service.addSource(repoPath, {
+      sourceIdOverride: "unsafe-update-source",
+    });
+    expect(added.ok).toBe(true);
+
+    const state = await stateStore.readState();
+    state.lockFile.sources["unsafe-update-source"] = {
+      ...state.lockFile.sources["unsafe-update-source"]!,
+      localPath: externalPath,
+    };
+    await stateStore.writeState(state);
+    const prepareSourceCheckout = vi.spyOn(checkoutService, "prepareSourceCheckout");
+
+    const updated = await service.updateSources(["unsafe-update-source"]);
+
+    expect(updated.ok).toBe(false);
+    if (updated.ok) {
+      return;
+    }
+    expect(updated.errors[0]?.code).toBe("SOURCE_CHECKOUT_PATH_INVALID");
+    expect(prepareSourceCheckout).not.toHaveBeenCalled();
+    await expect(fs.readFile(path.join(externalPath, "sentinel.txt"), "utf8"))
+      .resolves.toBe("keep");
+  });
+
   test("updateSources skips healthy git sources and repairs local drift", async () => {
     const stateStore = new StateStore(sandbox.stateRoot);
     await stateStore.init();
@@ -389,6 +428,17 @@ describe.sequential("SourceAuthorityService", () => {
     }
 
     const state = await stateStore.readState();
+    const gitCheckoutPath = path.join(
+      sandbox.stateRoot,
+      "source",
+      "git",
+      "git-fallback",
+    );
+    await fs.mkdir(path.dirname(gitCheckoutPath), { recursive: true });
+    await fs.rename(
+      state.lockFile.sources["git-fallback"]!.localPath,
+      gitCheckoutPath,
+    );
     state.manifest.sources[0] = {
       ...state.manifest.sources[0]!,
       kind: "git",
@@ -396,6 +446,7 @@ describe.sequential("SourceAuthorityService", () => {
     };
     state.lockFile.sources["git-fallback"] = {
       ...state.lockFile.sources["git-fallback"]!,
+      localPath: gitCheckoutPath,
       revision: { provider: "git", commit: "same-sha", capturedAt: new Date().toISOString() },
     };
     await stateStore.writeState(state);

--- a/packages/core-engine/src/tests/source-authority-service.test.ts
+++ b/packages/core-engine/src/tests/source-authority-service.test.ts
@@ -256,6 +256,44 @@ describe.sequential("SourceAuthorityService", () => {
       .resolves.toBe("keep");
   });
 
+  test("refuses to update a canonical checkout path that is a symbolic link", async () => {
+    const repoPath = await createRepo(sandbox.sandboxRoot, {
+      "skills/one/SKILL.md": skillDoc("one", "One."),
+    });
+    const externalPath = path.join(sandbox.sandboxRoot, "external-symlink-target");
+    await fs.mkdir(externalPath, { recursive: true });
+    await fs.writeFile(path.join(externalPath, "sentinel.txt"), "keep", "utf8");
+    const stateStore = new StateStore(sandbox.stateRoot);
+    await stateStore.init();
+    const checkoutService = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+    const service = new SourceAuthorityService({ stateStore, checkoutService });
+    const added = await service.addSource(repoPath, {
+      sourceIdOverride: "symlink-update-source",
+    });
+    expect(added.ok).toBe(true);
+    if (!added.ok) {
+      return;
+    }
+
+    await fs.rm(added.data.lock.localPath, { recursive: true, force: true });
+    await fs.symlink(externalPath, added.data.lock.localPath);
+    const prepareSourceCheckout = vi.spyOn(checkoutService, "prepareSourceCheckout");
+
+    const updated = await service.updateSources(["symlink-update-source"]);
+
+    expect(updated.ok).toBe(false);
+    if (updated.ok) {
+      return;
+    }
+    expect(updated.errors[0]?.code).toBe("SOURCE_CHECKOUT_PATH_INVALID");
+    expect(prepareSourceCheckout).not.toHaveBeenCalled();
+    await expect(fs.readFile(path.join(externalPath, "sentinel.txt"), "utf8"))
+      .resolves.toBe("keep");
+  });
+
   test("updateSources skips healthy git sources and repairs local drift", async () => {
     const stateStore = new StateStore(sandbox.stateRoot);
     await stateStore.init();

--- a/packages/core-engine/src/tests/source-authority-service.test.ts
+++ b/packages/core-engine/src/tests/source-authority-service.test.ts
@@ -294,7 +294,7 @@ describe.sequential("SourceAuthorityService", () => {
       .resolves.toBe("keep");
   });
 
-  test("updateSources skips healthy git sources and repairs local drift", async () => {
+  test("updateSources skips healthy git sources and repairs a missing managed directory or local drift", async () => {
     const stateStore = new StateStore(sandbox.stateRoot);
     await stateStore.init();
     const checkoutService = new SourceCheckoutService({
@@ -380,7 +380,7 @@ describe.sequential("SourceAuthorityService", () => {
       "git-unchanged:skills/one",
     ]);
 
-    await fs.rm(state.lockFile.sources["git-unchanged"]!.localPath, {
+    await fs.rm(path.dirname(state.lockFile.sources["git-unchanged"]!.localPath), {
       recursive: true,
       force: true,
     });

--- a/packages/core-engine/src/tests/source-authority-service.test.ts
+++ b/packages/core-engine/src/tests/source-authority-service.test.ts
@@ -265,6 +265,7 @@ describe.sequential("SourceAuthorityService", () => {
         }],
         invalidLeafs: [],
         commitSha: "same-sha",
+        originBranch: "release",
       },
     });
     expect(committed.ok).toBe(true);
@@ -287,6 +288,10 @@ describe.sequential("SourceAuthorityService", () => {
       return;
     }
     expect(prepareSourceCheckout).not.toHaveBeenCalled();
+    expect(checkoutService.readGitRemoteHeadCommit).toHaveBeenCalledWith(
+      "https://github.com/acme/skills.git",
+      { branch: "release" },
+    );
     expect(updated.data.updated).toEqual([
       expect.objectContaining({
         sourceId: "git-unchanged",

--- a/packages/core-engine/src/tests/source-checkout-service.test.ts
+++ b/packages/core-engine/src/tests/source-checkout-service.test.ts
@@ -59,6 +59,72 @@ describe.sequential("SourceCheckoutService", () => {
     );
   });
 
+  test("resolves the longest matching GitHub branch in a tree URL", async () => {
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
+    vi.spyOn(gitUtils, "git").mockResolvedValue([
+      "0123456789abcdef0123456789abcdef01234567\trefs/heads/feature",
+      "89abcdef0123456789abcdef0123456789abcdef\trefs/heads/feature/foo",
+    ].join("\n"));
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    await expect(service.resolveSource(
+      "https://github.com/acme/skills/tree/feature/foo/skills/one",
+      {},
+    )).resolves.toMatchObject({
+      kind: "git",
+      locator: "https://github.com/acme/skills.git",
+      originBranch: "feature/foo",
+      requestedPath: "skills/one",
+    });
+  });
+
+  test("uses the GitHub API to resolve a tree branch when git is unavailable", async () => {
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(false);
+    const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      return new Response("", {
+        status: url.endsWith("/branches/feature%2Ffoo") ? 200 : 404,
+      });
+    });
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    await expect(service.resolveSource(
+      "https://github.com/acme/skills/tree/feature/foo/skills/one",
+      {},
+    )).resolves.toMatchObject({
+      originBranch: "feature/foo",
+      requestedPath: "skills/one",
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/skills/branches/feature%2Ffoo%2Fskills",
+      expect.any(Object),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/skills/branches/feature%2Ffoo",
+      expect.any(Object),
+    );
+  });
+
+  test("rejects a GitHub tree URL when its branch cannot be resolved", async () => {
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(false);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 404 }));
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    await expect(service.resolveSource(
+      "https://github.com/acme/skills/tree/missing/skills/one",
+      {},
+    )).rejects.toThrow("Unable to resolve a GitHub branch");
+  });
+
   test("reads remote HEAD commit for GitHub shorthand locators", async () => {
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     const git = vi.spyOn(gitUtils, "git").mockResolvedValue(
@@ -334,6 +400,9 @@ describe.sequential("SourceCheckoutService", () => {
     });
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
+      if (args[0] === "ls-remote" && args[1] === "--heads") {
+        return "test-commit-sha\trefs/heads/main";
+      }
       if (
         args[0] === "clone"
         && args[3] === "--branch"

--- a/packages/core-engine/src/tests/source-checkout-service.test.ts
+++ b/packages/core-engine/src/tests/source-checkout-service.test.ts
@@ -59,72 +59,6 @@ describe.sequential("SourceCheckoutService", () => {
     );
   });
 
-  test("resolves the longest matching GitHub branch in a tree URL", async () => {
-    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
-    vi.spyOn(gitUtils, "git").mockResolvedValue([
-      "0123456789abcdef0123456789abcdef01234567\trefs/heads/feature",
-      "89abcdef0123456789abcdef0123456789abcdef\trefs/heads/feature/foo",
-    ].join("\n"));
-    const service = new SourceCheckoutService({
-      sourceRoot: path.join(sandbox.stateRoot, "source"),
-      inventoryService: new InventoryService(),
-    });
-
-    await expect(service.resolveSource(
-      "https://github.com/acme/skills/tree/feature/foo/skills/one",
-      {},
-    )).resolves.toMatchObject({
-      kind: "git",
-      locator: "https://github.com/acme/skills.git",
-      originBranch: "feature/foo",
-      requestedPath: "skills/one",
-    });
-  });
-
-  test("uses the GitHub API to resolve a tree branch when git is unavailable", async () => {
-    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(false);
-    const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = String(input);
-      return new Response("", {
-        status: url.endsWith("/branches/feature%2Ffoo") ? 200 : 404,
-      });
-    });
-    const service = new SourceCheckoutService({
-      sourceRoot: path.join(sandbox.stateRoot, "source"),
-      inventoryService: new InventoryService(),
-    });
-
-    await expect(service.resolveSource(
-      "https://github.com/acme/skills/tree/feature/foo/skills/one",
-      {},
-    )).resolves.toMatchObject({
-      originBranch: "feature/foo",
-      requestedPath: "skills/one",
-    });
-    expect(fetch).toHaveBeenCalledWith(
-      "https://api.github.com/repos/acme/skills/branches/feature%2Ffoo%2Fskills",
-      expect.any(Object),
-    );
-    expect(fetch).toHaveBeenCalledWith(
-      "https://api.github.com/repos/acme/skills/branches/feature%2Ffoo",
-      expect.any(Object),
-    );
-  });
-
-  test("rejects a GitHub tree URL when its branch cannot be resolved", async () => {
-    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(false);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 404 }));
-    const service = new SourceCheckoutService({
-      sourceRoot: path.join(sandbox.stateRoot, "source"),
-      inventoryService: new InventoryService(),
-    });
-
-    await expect(service.resolveSource(
-      "https://github.com/acme/skills/tree/missing/skills/one",
-      {},
-    )).rejects.toThrow("Unable to resolve a GitHub branch");
-  });
-
   test("reads remote HEAD commit for GitHub shorthand locators", async () => {
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     const git = vi.spyOn(gitUtils, "git").mockResolvedValue(
@@ -275,6 +209,7 @@ describe.sequential("SourceCheckoutService", () => {
       {
         checkoutPath,
         existingCheckoutPath,
+        updateBranch: "release",
         options: { sourceIdOverride: "git-existing", originBranch: "release" },
       },
     );
@@ -284,6 +219,10 @@ describe.sequential("SourceCheckoutService", () => {
       return;
     }
     expect(prepared.data.commitSha).toBe("fedcba9876543210fedcba9876543210fedcba98");
+    expect(gitUtils.git).toHaveBeenCalledWith(
+      ["fetch", "--depth", "1", "origin", "refs/heads/release"],
+      { cwd: checkoutPath },
+    );
     await expect(fs.readFile(
       path.join(checkoutPath, "skills", "one", "SKILL.md"),
       "utf8",
@@ -313,6 +252,20 @@ describe.sequential("SourceCheckoutService", () => {
         await fs.cp(upstreamRepo, checkoutPath, { recursive: true });
         return "";
       }
+      if (
+        args[0] === "fetch"
+        && args[4] === "refs/heads/release"
+        && options?.cwd === checkoutPath
+      ) {
+        return "";
+      }
+      if (
+        args[0] === "checkout"
+        && args[1] === "--detach"
+        && options?.cwd === checkoutPath
+      ) {
+        return "";
+      }
       if (args[0] === "rev-parse" && args[1] === "HEAD" && options?.cwd === checkoutPath) {
         return "abcdef0123456789abcdef0123456789abcdef01";
       }
@@ -328,6 +281,7 @@ describe.sequential("SourceCheckoutService", () => {
       {
         checkoutPath,
         existingCheckoutPath,
+        updateBranch: "release",
         options: { sourceIdOverride: "git-fallback", originBranch: "release" },
       },
     );
@@ -342,6 +296,10 @@ describe.sequential("SourceCheckoutService", () => {
       "https://github.com/acme/skills.git",
       checkoutPath,
     ]);
+    expect(git).toHaveBeenCalledWith(
+      ["fetch", "--depth", "1", "origin", "refs/heads/release"],
+      { cwd: checkoutPath },
+    );
     await expect(fs.readFile(
       path.join(checkoutPath, "skills", "one", "SKILL.md"),
       "utf8",
@@ -360,7 +318,10 @@ describe.sequential("SourceCheckoutService", () => {
 
     const prepared = await service.prepareSourceCheckout(
       "https://github.com/acme/skills.git",
-      { options: { sourceIdOverride: "locked-release", originBranch: "release" } },
+      {
+        updateBranch: "release",
+        options: { sourceIdOverride: "locked-release", originBranch: "release" },
+      },
     );
 
     expect(prepared.ok).toBe(false);
@@ -400,16 +361,8 @@ describe.sequential("SourceCheckoutService", () => {
     });
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
-      if (args[0] === "ls-remote" && args[1] === "--heads") {
-        return "test-commit-sha\trefs/heads/main";
-      }
-      if (
-        args[0] === "clone"
-        && args[3] === "--branch"
-        && args[4] === "main"
-        && args[5] === "https://github.com/vercel-labs/skills.git"
-      ) {
-        await fs.cp(upstreamRepo, args[6]!, { recursive: true });
+      if (args[0] === "clone" && args[3] === "https://github.com/vercel-labs/skills.git") {
+        await fs.cp(upstreamRepo, args[4]!, { recursive: true });
         return "";
       }
 
@@ -434,7 +387,6 @@ describe.sequential("SourceCheckoutService", () => {
       return;
     }
     expect(prepared.data.kind).toBe("git");
-    expect(prepared.data.originBranch).toBe("main");
     expect(prepared.data.requestedPath).toBe("skills/find-skills");
     expect(prepared.data.checkoutPath).toContain(`${path.sep}source${path.sep}git${path.sep}`);
     expect(prepared.data.leafs.map((leaf) => leaf.id)).toEqual([

--- a/packages/core-engine/src/tests/source-checkout-service.test.ts
+++ b/packages/core-engine/src/tests/source-checkout-service.test.ts
@@ -59,6 +59,42 @@ describe.sequential("SourceCheckoutService", () => {
     );
   });
 
+  test("reads remote HEAD commit for GitHub shorthand locators", async () => {
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
+    const git = vi.spyOn(gitUtils, "git").mockResolvedValue(
+      "0123456789abcdef0123456789abcdef01234567\tHEAD",
+    );
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    await expect(service.readGitRemoteHeadCommit("acme/skills"))
+      .resolves.toBe("0123456789abcdef0123456789abcdef01234567");
+    expect(git).toHaveBeenCalledWith(
+      ["ls-remote", "https://github.com/acme/skills.git", "HEAD"],
+      { timeoutMs: 5_000 },
+    );
+  });
+
+  test("reads the configured remote branch commit", async () => {
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
+    const git = vi.spyOn(gitUtils, "git").mockResolvedValue(
+      "89abcdef0123456789abcdef0123456789abcdef\trefs/heads/release",
+    );
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    await expect(service.readGitRemoteHeadCommit("acme/skills", { branch: "release" }))
+      .resolves.toBe("89abcdef0123456789abcdef0123456789abcdef");
+    expect(git).toHaveBeenCalledWith(
+      ["ls-remote", "https://github.com/acme/skills.git", "refs/heads/release"],
+      { timeoutMs: 5_000 },
+    );
+  });
+
   test("accepts SHA-256 remote HEAD commits", async () => {
     const sha256 = "0123456789abcdef".repeat(4);
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
@@ -122,6 +158,152 @@ describe.sequential("SourceCheckoutService", () => {
     await expect(fs.access(path.join(sandbox.stateRoot, "collections.json"))).rejects.toThrow();
   });
 
+  test("refreshes a git checkout from its existing object store", async () => {
+    const existingCheckoutPath = path.join(sandbox.sandboxRoot, "existing-checkout");
+    const checkoutPath = path.join(sandbox.stateRoot, "source", "git", ".update-existing");
+    await fs.mkdir(path.join(existingCheckoutPath, ".git"), { recursive: true });
+    await fs.mkdir(path.join(existingCheckoutPath, "skills", "one"), { recursive: true });
+    await fs.writeFile(
+      path.join(existingCheckoutPath, "skills", "one", "SKILL.md"),
+      skillDoc("one", "Old."),
+      "utf8",
+    );
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
+    vi.spyOn(gitUtils, "git").mockImplementation(async (args, options) => {
+      if (
+        args[0] === "clone"
+        && args[1] === "--local"
+        && args[2] === "--no-checkout"
+        && args[3] === existingCheckoutPath
+        && args[4] === checkoutPath
+      ) {
+        await fs.cp(existingCheckoutPath, checkoutPath, { recursive: true });
+        return "";
+      }
+      if (args[0] === "remote" && args[1] === "set-url" && options?.cwd === checkoutPath) {
+        return "";
+      }
+      if (args[0] === "fetch" && options?.cwd === checkoutPath) {
+        return "";
+      }
+      if (args[0] === "checkout" && options?.cwd === checkoutPath) {
+        await fs.writeFile(
+          path.join(checkoutPath, "skills", "one", "SKILL.md"),
+          skillDoc("one", "New."),
+          "utf8",
+        );
+        return "";
+      }
+      if (args[0] === "rev-parse" && args[1] === "HEAD" && options?.cwd === checkoutPath) {
+        return "fedcba9876543210fedcba9876543210fedcba98";
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    const prepared = await service.prepareSourceCheckout(
+      "git@example.test:acme/skills.git",
+      {
+        checkoutPath,
+        existingCheckoutPath,
+        options: { sourceIdOverride: "git-existing", originBranch: "release" },
+      },
+    );
+
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) {
+      return;
+    }
+    expect(prepared.data.commitSha).toBe("fedcba9876543210fedcba9876543210fedcba98");
+    await expect(fs.readFile(
+      path.join(checkoutPath, "skills", "one", "SKILL.md"),
+      "utf8",
+    )).resolves.toContain("New.");
+  });
+
+  test("falls back to a clean clone when the existing checkout cannot be refreshed", async () => {
+    const existingCheckoutPath = path.join(sandbox.sandboxRoot, "broken-existing-checkout");
+    const upstreamRepo = await createRepo(sandbox.sandboxRoot, {
+      "skills/one/SKILL.md": skillDoc("one", "Fresh."),
+    });
+    const checkoutPath = path.join(sandbox.stateRoot, "source", "git", ".update-fallback");
+    await fs.mkdir(path.join(existingCheckoutPath, ".git"), { recursive: true });
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
+    const git = vi.spyOn(gitUtils, "git").mockImplementation(async (args, options) => {
+      if (args[0] === "clone" && args[1] === "--local") {
+        throw new Error("local clone failed");
+      }
+      if (
+        args[0] === "clone"
+        && args[1] === "--depth"
+        && args[3] === "--branch"
+        && args[4] === "release"
+        && args[5] === "https://github.com/acme/skills.git"
+        && args[6] === checkoutPath
+      ) {
+        await fs.cp(upstreamRepo, checkoutPath, { recursive: true });
+        return "";
+      }
+      if (args[0] === "rev-parse" && args[1] === "HEAD" && options?.cwd === checkoutPath) {
+        return "abcdef0123456789abcdef0123456789abcdef01";
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    const prepared = await service.prepareSourceCheckout(
+      "https://github.com/acme/skills.git",
+      {
+        checkoutPath,
+        existingCheckoutPath,
+        options: { sourceIdOverride: "git-fallback", originBranch: "release" },
+      },
+    );
+
+    expect(prepared.ok).toBe(true);
+    expect(git).toHaveBeenCalledWith([
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      "release",
+      "https://github.com/acme/skills.git",
+      checkoutPath,
+    ]);
+    await expect(fs.readFile(
+      path.join(checkoutPath, "skills", "one", "SKILL.md"),
+      "utf8",
+    )).resolves.toContain("Fresh.");
+  });
+
+  test("does not switch branches when a locked branch archive is unavailable", async () => {
+    vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(false);
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("missing", { status: 404 }),
+    );
+    const service = new SourceCheckoutService({
+      sourceRoot: path.join(sandbox.stateRoot, "source"),
+      inventoryService: new InventoryService(),
+    });
+
+    const prepared = await service.prepareSourceCheckout(
+      "https://github.com/acme/skills.git",
+      { options: { sourceIdOverride: "locked-release", originBranch: "release" } },
+    );
+
+    expect(prepared.ok).toBe(false);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0]?.[0]).toBe(
+      "https://github.com/acme/skills/archive/refs/heads/release.zip",
+    );
+  });
+
   test("rejects skill leafs with escaping symlinks before they can be deployed", async () => {
     const repoPath = await createRepo(sandbox.sandboxRoot, {
       "skills/unsafe/SKILL.md": skillDoc("unsafe", "Unsafe skill."),
@@ -152,8 +334,13 @@ describe.sequential("SourceCheckoutService", () => {
     });
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
-      if (args[0] === "clone" && args[3] === "https://github.com/vercel-labs/skills.git") {
-        await fs.cp(upstreamRepo, args[4]!, { recursive: true });
+      if (
+        args[0] === "clone"
+        && args[3] === "--branch"
+        && args[4] === "main"
+        && args[5] === "https://github.com/vercel-labs/skills.git"
+      ) {
+        await fs.cp(upstreamRepo, args[6]!, { recursive: true });
         return "";
       }
 
@@ -178,6 +365,7 @@ describe.sequential("SourceCheckoutService", () => {
       return;
     }
     expect(prepared.data.kind).toBe("git");
+    expect(prepared.data.originBranch).toBe("main");
     expect(prepared.data.requestedPath).toBe("skills/find-skills");
     expect(prepared.data.checkoutPath).toContain(`${path.sep}source${path.sep}git${path.sep}`);
     expect(prepared.data.leafs.map((leaf) => leaf.id)).toEqual([

--- a/packages/integration/src/tests/fs-utils.test.ts
+++ b/packages/integration/src/tests/fs-utils.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, test } from "vitest";
-import { hashDirectory } from "../utils/fs.js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { hashDirectory, withFileLock } from "../utils/fs.js";
 
 describe("hashDirectory", () => {
   const roots: string[] = [];
@@ -29,5 +29,86 @@ describe("hashDirectory", () => {
     await fs.symlink("../outside", path.join(root, "escape"));
 
     await expect(hashDirectory(root, { symlinkPolicy: "preserve-safe" })).rejects.toThrow("Unsafe symbolic link");
+  });
+
+  test("reclaims a recent lock owned by a dead process", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-fs-"));
+    roots.push(root);
+    const lockPath = path.join(root, ".mutation.lock");
+    await fs.mkdir(lockPath);
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({ pid: 2_147_483_647, acquiredAt: new Date().toISOString() })}\n`,
+      "utf8",
+    );
+
+    await expect(withFileLock(
+      lockPath,
+      async () => "acquired",
+      { pollMs: 5, staleMs: 60_000, timeoutMs: 30 },
+    )).resolves.toBe("acquired");
+  });
+
+  test("does not reclaim a recent lock owned by a live process", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-fs-"));
+    roots.push(root);
+    const lockPath = path.join(root, ".mutation.lock");
+    await fs.mkdir(lockPath);
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`,
+      "utf8",
+    );
+
+    await expect(withFileLock(
+      lockPath,
+      async () => "unexpected",
+      { pollMs: 5, staleMs: 60_000, timeoutMs: 20 },
+    )).rejects.toThrow("Timed out waiting for state lock");
+  });
+
+  test("does not reclaim a stale lock owned by a live process", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-fs-"));
+    roots.push(root);
+    const lockPath = path.join(root, ".mutation.lock");
+    await fs.mkdir(lockPath);
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({ pid: process.pid, acquiredAt: new Date(0).toISOString() })}\n`,
+      "utf8",
+    );
+    await fs.utimes(lockPath, new Date(0), new Date(0));
+
+    await expect(withFileLock(
+      lockPath,
+      async () => "unexpected",
+      { pollMs: 5, staleMs: 1, timeoutMs: 20 },
+    )).rejects.toThrow("Timed out waiting for state lock");
+  });
+
+  test("treats a permission-denied owner probe as a live process", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-fs-"));
+    roots.push(root);
+    const lockPath = path.join(root, ".mutation.lock");
+    await fs.mkdir(lockPath);
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({ pid: 42, acquiredAt: new Date(0).toISOString() })}\n`,
+      "utf8",
+    );
+    await fs.utimes(lockPath, new Date(0), new Date(0));
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("Operation not permitted"), { code: "EPERM" });
+    });
+
+    try {
+      await expect(withFileLock(
+        lockPath,
+        async () => "unexpected",
+        { pollMs: 5, staleMs: 1, timeoutMs: 20 },
+      )).rejects.toThrow("Timed out waiting for state lock");
+    } finally {
+      kill.mockRestore();
+    }
   });
 });

--- a/packages/integration/src/utils/fs.ts
+++ b/packages/integration/src/utils/fs.ts
@@ -63,9 +63,11 @@ export async function withFileLock<T>(
         throw error;
       }
 
-      const stale = await isLockStale(lockPath, staleMs);
-      if (stale) {
-        await fs.rm(lockPath, { recursive: true, force: true });
+      const ownerState = await readLockOwnerState(lockPath);
+      const reclaimable = ownerState === "dead"
+        || (ownerState === "unknown" && await isLockStale(lockPath, staleMs));
+      if (reclaimable) {
+        await reclaimFileLock(lockPath);
         continue;
       }
 
@@ -193,6 +195,56 @@ async function isLockStale(lockPath: string, staleMs: number) {
   } catch {
     return false;
   }
+}
+
+async function readLockOwnerState(
+  lockPath: string,
+): Promise<"alive" | "dead" | "unknown"> {
+  const owner = await readJsonFile<FileLockMetadata | null>(
+    path.join(lockPath, "owner.json"),
+    null,
+  );
+  const pid = owner?.pid;
+  if (!Number.isSafeInteger(pid) || !pid || pid <= 0) {
+    return "unknown";
+  }
+
+  try {
+    process.kill(pid, 0);
+    return "alive";
+  } catch (error) {
+    if (
+      typeof error === "object"
+      && error !== null
+      && "code" in error
+    ) {
+      if (error.code === "ESRCH") {
+        return "dead";
+      }
+      if (error.code === "EPERM") {
+        return "alive";
+      }
+    }
+    return "unknown";
+  }
+}
+
+async function reclaimFileLock(lockPath: string): Promise<void> {
+  const quarantinePath = `${lockPath}.reclaim-${process.pid}-${crypto.randomUUID()}`;
+  try {
+    await fs.rename(lockPath, quarantinePath);
+  } catch (error) {
+    if (
+      typeof error === "object"
+      && error !== null
+      && "code" in error
+      && (error.code === "ENOENT" || error.code === "EEXIST")
+    ) {
+      return;
+    }
+    throw error;
+  }
+  await fs.rm(quarantinePath, { recursive: true, force: true });
 }
 
 function isAlreadyExistsError(error: unknown) {

--- a/packages/integration/src/utils/github-catalog.ts
+++ b/packages/integration/src/utils/github-catalog.ts
@@ -1,6 +1,5 @@
 import type { SourceStats } from "@skill-flow/domain/types";
 import { fetchWithTimeout } from "./fetch-timeout.js";
-import { git, isGitAvailable } from "./git.js";
 import { parseGitHubRepo } from "./naming.js";
 
 type GitHubTreeResponse = {
@@ -20,72 +19,6 @@ type GitHubRepoResponse = {
   default_branch?: string;
   pushed_at?: string;
 };
-
-export type GitHubTreePathResolution = {
-  branch: string;
-  requestedPath: string;
-};
-
-export async function resolveGitHubTreePath(
-  locator: string,
-  treePath: string,
-): Promise<GitHubTreePathResolution> {
-  const repo = parseGitHubRepo(locator);
-  if (!repo) {
-    throw new Error(`Unsupported GitHub locator '${locator}'.`);
-  }
-
-  const segments = treePath
-    .split("/")
-    .filter(Boolean)
-    .map((segment) => decodeURIComponent(segment));
-  const candidates = Array.from(
-    { length: Math.max(segments.length - 1, 0) },
-    (_, index) => {
-      const branchSegmentCount = segments.length - index - 1;
-      return {
-        branch: segments.slice(0, branchSegmentCount).join("/"),
-        requestedPath: segments.slice(branchSegmentCount).join("/"),
-      };
-    },
-  );
-  if (candidates.length === 0) {
-    throw new Error(`GitHub tree URL '${treePath}' must include a branch and repository path.`);
-  }
-
-  if (await isGitAvailable()) {
-    try {
-      const output = await git(["ls-remote", "--heads", locator], { timeoutMs: 5_000 });
-      const branches = new Set(
-        output
-          .split(/\r?\n/)
-          .map((line) => line.trim().match(/\srefs\/heads\/(.+)$/)?.[1])
-          .filter((branch): branch is string => Boolean(branch)),
-      );
-      const matched = candidates.find((candidate) => branches.has(candidate.branch));
-      if (matched) {
-        return matched;
-      }
-    } catch {
-      // GitHub's API keeps tree URL imports available when git probing fails.
-    }
-  }
-
-  for (const candidate of candidates) {
-    const response = await fetchWithTimeout(
-      `https://api.github.com/repos/${repo.owner}/${repo.repo}/branches/${encodeURIComponent(candidate.branch)}`,
-      { headers: buildGitHubHeaders() },
-    );
-    if (response.ok) {
-      return candidate;
-    }
-    if (response.status !== 404) {
-      throw new Error(`GitHub branch request failed with ${response.status}.`);
-    }
-  }
-
-  throw new Error(`Unable to resolve a GitHub branch from tree path '${treePath}'.`);
-}
 
 export async function fetchGitHubSkillPaths(
   locator: string,

--- a/packages/integration/src/utils/github-catalog.ts
+++ b/packages/integration/src/utils/github-catalog.ts
@@ -1,5 +1,6 @@
 import type { SourceStats } from "@skill-flow/domain/types";
 import { fetchWithTimeout } from "./fetch-timeout.js";
+import { git, isGitAvailable } from "./git.js";
 import { parseGitHubRepo } from "./naming.js";
 
 type GitHubTreeResponse = {
@@ -19,6 +20,72 @@ type GitHubRepoResponse = {
   default_branch?: string;
   pushed_at?: string;
 };
+
+export type GitHubTreePathResolution = {
+  branch: string;
+  requestedPath: string;
+};
+
+export async function resolveGitHubTreePath(
+  locator: string,
+  treePath: string,
+): Promise<GitHubTreePathResolution> {
+  const repo = parseGitHubRepo(locator);
+  if (!repo) {
+    throw new Error(`Unsupported GitHub locator '${locator}'.`);
+  }
+
+  const segments = treePath
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => decodeURIComponent(segment));
+  const candidates = Array.from(
+    { length: Math.max(segments.length - 1, 0) },
+    (_, index) => {
+      const branchSegmentCount = segments.length - index - 1;
+      return {
+        branch: segments.slice(0, branchSegmentCount).join("/"),
+        requestedPath: segments.slice(branchSegmentCount).join("/"),
+      };
+    },
+  );
+  if (candidates.length === 0) {
+    throw new Error(`GitHub tree URL '${treePath}' must include a branch and repository path.`);
+  }
+
+  if (await isGitAvailable()) {
+    try {
+      const output = await git(["ls-remote", "--heads", locator], { timeoutMs: 5_000 });
+      const branches = new Set(
+        output
+          .split(/\r?\n/)
+          .map((line) => line.trim().match(/\srefs\/heads\/(.+)$/)?.[1])
+          .filter((branch): branch is string => Boolean(branch)),
+      );
+      const matched = candidates.find((candidate) => branches.has(candidate.branch));
+      if (matched) {
+        return matched;
+      }
+    } catch {
+      // GitHub's API keeps tree URL imports available when git probing fails.
+    }
+  }
+
+  for (const candidate of candidates) {
+    const response = await fetchWithTimeout(
+      `https://api.github.com/repos/${repo.owner}/${repo.repo}/branches/${encodeURIComponent(candidate.branch)}`,
+      { headers: buildGitHubHeaders() },
+    );
+    if (response.ok) {
+      return candidate;
+    }
+    if (response.status !== 404) {
+      throw new Error(`GitHub branch request failed with ${response.status}.`);
+    }
+  }
+
+  throw new Error(`Unable to resolve a GitHub branch from tree path '${treePath}'.`);
+}
 
 export async function fetchGitHubSkillPaths(
   locator: string,

--- a/packages/query/src/tests/source-lifecycle.test.ts
+++ b/packages/query/src/tests/source-lifecycle.test.ts
@@ -879,6 +879,9 @@ describe.sequential("source lifecycle", () => {
     });
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
+      if (args[0] === "ls-remote" && args[1] === "--heads") {
+        return "test-commit-sha\trefs/heads/main";
+      }
       if (
         args[0] === "clone"
         && args[3] === "--branch"
@@ -925,6 +928,9 @@ describe.sequential("source lifecycle", () => {
     });
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
+      if (args[0] === "ls-remote" && args[1] === "--heads") {
+        return "test-commit-sha\trefs/heads/main";
+      }
       if (
         args[0] === "clone"
         && args[3] === "--branch"
@@ -1509,6 +1515,12 @@ description: |
       return;
     }
     const commit = await gitUtils.git(["rev-parse", "HEAD"], { cwd: repoPath });
+    const gitCheckoutPath = path.join(
+      sandbox.stateRoot,
+      "source",
+      "git",
+      sourceId,
+    );
     await v2(app).writeState({
       ...before,
       manifest: {
@@ -1523,6 +1535,7 @@ description: |
           ...before.lockFile.sources,
           [sourceId]: {
             ...before.lockFile.sources[sourceId]!,
+            localPath: gitCheckoutPath,
             revision: { provider: "git", commit, capturedAt: new Date().toISOString() },
           },
         },

--- a/packages/query/src/tests/source-lifecycle.test.ts
+++ b/packages/query/src/tests/source-lifecycle.test.ts
@@ -879,8 +879,13 @@ describe.sequential("source lifecycle", () => {
     });
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
-      if (args[0] === "clone" && args[3] === "https://github.com/vercel-labs/skills.git") {
-        await fs.cp(upstreamRepo, args[4]!, { recursive: true });
+      if (
+        args[0] === "clone"
+        && args[3] === "--branch"
+        && args[4] === "main"
+        && args[5] === "https://github.com/vercel-labs/skills.git"
+      ) {
+        await fs.cp(upstreamRepo, args[6]!, { recursive: true });
         return "";
       }
 
@@ -908,6 +913,7 @@ describe.sequential("source lifecycle", () => {
     const lock = state.lockFile.sources[result.data.manifest.id];
     expect(source?.kind).toBe("git");
     expect(lock?.revision.provider).toBe("git");
+    expect(lock?.originBranch).toBe("main");
     expect(lock?.localPath).toBe(
       app.store.getSourceCheckoutPath("git", result.data.manifest.id),
     );
@@ -919,8 +925,13 @@ describe.sequential("source lifecycle", () => {
     });
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
-      if (args[0] === "clone" && args[3] === "https://github.com/vercel-labs/skills.git") {
-        await fs.cp(upstreamRepo, args[4]!, { recursive: true });
+      if (
+        args[0] === "clone"
+        && args[3] === "--branch"
+        && args[4] === "main"
+        && args[5] === "https://github.com/vercel-labs/skills.git"
+      ) {
+        await fs.cp(upstreamRepo, args[6]!, { recursive: true });
         return "";
       }
 

--- a/packages/query/src/tests/source-lifecycle.test.ts
+++ b/packages/query/src/tests/source-lifecycle.test.ts
@@ -879,16 +879,8 @@ describe.sequential("source lifecycle", () => {
     });
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
-      if (args[0] === "ls-remote" && args[1] === "--heads") {
-        return "test-commit-sha\trefs/heads/main";
-      }
-      if (
-        args[0] === "clone"
-        && args[3] === "--branch"
-        && args[4] === "main"
-        && args[5] === "https://github.com/vercel-labs/skills.git"
-      ) {
-        await fs.cp(upstreamRepo, args[6]!, { recursive: true });
+      if (args[0] === "clone" && args[3] === "https://github.com/vercel-labs/skills.git") {
+        await fs.cp(upstreamRepo, args[4]!, { recursive: true });
         return "";
       }
 
@@ -916,7 +908,6 @@ describe.sequential("source lifecycle", () => {
     const lock = state.lockFile.sources[result.data.manifest.id];
     expect(source?.kind).toBe("git");
     expect(lock?.revision.provider).toBe("git");
-    expect(lock?.originBranch).toBe("main");
     expect(lock?.localPath).toBe(
       app.store.getSourceCheckoutPath("git", result.data.manifest.id),
     );
@@ -928,16 +919,8 @@ describe.sequential("source lifecycle", () => {
     });
     vi.spyOn(gitUtils, "isGitAvailable").mockResolvedValue(true);
     vi.spyOn(gitUtils, "git").mockImplementation(async (args) => {
-      if (args[0] === "ls-remote" && args[1] === "--heads") {
-        return "test-commit-sha\trefs/heads/main";
-      }
-      if (
-        args[0] === "clone"
-        && args[3] === "--branch"
-        && args[4] === "main"
-        && args[5] === "https://github.com/vercel-labs/skills.git"
-      ) {
-        await fs.cp(upstreamRepo, args[6]!, { recursive: true });
+      if (args[0] === "clone" && args[3] === "https://github.com/vercel-labs/skills.git") {
+        await fs.cp(upstreamRepo, args[4]!, { recursive: true });
         return "";
       }
 


### PR DESCRIPTION
## Summary

This PR improves the managed Git source update path by:

1. Skipping checkout preparation when the locked commit already matches the selected remote branch.
2. Preserving branch identity throughout remote preflight, staged refresh, clean clone, and archive fallback.
3. Validating managed checkout ownership before reading, renaming, or replacing a checkout.
4. Protecting active long-running mutations with PID-aware lock handling.
5. Applying bounded desktop update timeouts that scale with the selected source count.

The implementation follows the existing source authority, partial-update, staged replacement, and bridge execution models.

## Motivation

Previously, a managed Git update prepared a new checkout before determining whether the remote commit had changed. This caused unnecessary Git and filesystem work for sources that were already current.

Long-running updates could also cross two existing limits:

- A desktop bridge command could time out before a legitimate multi-source update completed.
- A filesystem lock could be considered stale based only on age, even while its owning process was still running.

The update path also relied on `lock.localPath` during checkout replacement. Managed checkout ownership therefore needed to be verified before any remote preflight, local reuse, rename, or replacement operation.

## Core changes

### Remote commit preflight

For managed Git sources with a locked commit, the update path now:

- normalizes the Git locator;
- queries the exact locked branch when `originBranch` is available;
- compares the remote commit with the locked commit;
- inspects local checkout integrity when both commits match;
- skips checkout preparation when the checkout is healthy;
- performs the established full update flow when the remote commit cannot be verified.

This makes the confirmed-unchanged path inexpensive while preserving the existing recovery behavior for uncertain or damaged states.

### Branch-preserving staged refresh

When the remote commit has changed, the update path:

1. Attempts to prepare a temporary checkout from the existing managed Git checkout.
2. Sets the requested remote locator.
3. Fetches the exact remote ref.
4. Checks out `FETCH_HEAD` in detached mode.
5. Validates the prepared source snapshot.
6. Atomically replaces the managed checkout.

If local preparation fails, the update continues through the established clean clone, HTTPS fallback, and archive fallback sequence.

When `lock.originBranch` is present, the same branch is used consistently by remote preflight, staged fetch, clean clone, and archive fallback. The clean-fetch path explicitly fetches `refs/heads/<originBranch>` before accepting the result, ensuring that the final checkout resolves to the requested branch rather than a same-named tag.

Locks without `originBranch` retain the established default-branch behavior.

### Managed checkout ownership validation

Before any update-side checkout operation, the service verifies that:

- `lock.localPath` exactly matches `<stateRoot>/source/<sourceKind>/<sourceId>`;
- the normalized path remains under the managed source root;
- the source root, source-kind directory, and checkout are not symbolic links;
- resolved real paths remain under the real managed source root.

An invalid path returns `SOURCE_CHECKOUT_PATH_INVALID` before the referenced checkout is read or modified. External sources continue to leave the managed update path before managed checkout validation.

### PID-aware mutation locking

Mutation lock recovery now considers the owner process:

- a confirmed live owner keeps the lock;
- a confirmed dead owner allows immediate reclamation;
- missing or unreadable owner metadata uses the existing age-based stale rule;
- reclamation first renames the lock to a quarantine path before removing it.

This keeps long-running updates serialized without leaving dead locks permanently behind.

### Bounded desktop update execution

Desktop update commands use a dedicated timeout budget:

- one explicitly selected source: 5 minutes;
- two sources: 10 minutes;
- three or more sources: 15 minutes;
- update all: 15 minutes.

Selected source IDs are deduplicated before calculating the timeout. Overflow is handled explicitly, and the result is always capped at 15 minutes.

## Update flow

```text
Validate managed checkout ownership
  -> Read the locked commit and branch
  -> Query the corresponding remote ref
  -> If unchanged, verify local integrity and return
  -> If changed or uncertain, prepare a staged checkout
  -> Validate the staged snapshot
  -> Atomically replace the managed checkout
  -> Persist the updated lock and inventory
```

Per-source fetch failures continue through the existing partial-update result model. Authority failures such as an invalid managed checkout path stop before checkout preparation.

## Verification

- `npm run build`
- `@skill-flow/integration`: `fs-utils.test.ts` — 6 passed
- `@skill-flow/core-engine`: `source-checkout-service.test.ts` and `source-authority-service.test.ts` — 22 passed
- `@skill-flow/query`: `source-lifecycle.test.ts` — 50 passed
- Xcode 26.5 GitHub Actions validation: updated-source tests, macOS production target compilation, release packaging, and artifact validation passed

---

## 中文概要

本 PR 对托管 Git 来源更新链路进行了以下改进：

1. 当 lock commit 已与目标远端分支一致时，跳过 checkout 准备。
2. 在远端预检、暂存刷新、干净 clone 和 archive fallback 中保持一致的分支身份。
3. 在读取、重命名或替换 checkout 之前验证托管路径所有权。
4. 通过感知 PID 的锁处理保护长时间运行的 mutation。
5. 根据来源数量为桌面更新分配有明确上限的执行时间。

实现继续沿用现有的 source authority、partial update、暂存替换和 bridge 执行模型。

## 背景

修改前，托管 Git 来源在确认远端 commit 是否变化之前，就会准备新的 checkout。因此，即使来源已经是最新状态，也会发生不必要的 Git 和文件系统操作。

长时间更新还可能跨越两个既有限制：

- 桌面 bridge 可能在合法的多来源更新完成之前超时。
- 文件锁只根据时间判断 stale，即使持有锁的进程仍在运行，也可能被其他进程回收。

更新流程还会在替换 checkout 时使用 `lock.localPath`，因此必须在远端预检、本地复用、rename 和 replacement 之前验证托管路径所有权。

## 核心改进

### 远端 commit 预检

对于已经记录 commit 的托管 Git 来源，更新流程现在会规范化 Git locator，在存在 `originBranch` 时查询该精确分支，并比较远端 commit 与 lock commit。Commit 相同且本地 checkout 完整时会直接跳过 checkout 准备；无法确认远端 commit 时则进入既有的完整更新流程。

这使已经确认未变化的来源能够快速完成，同时保留不确定状态和损坏状态下的恢复行为。

### 保持分支身份的暂存刷新

当远端 commit 已发生变化时，更新流程会：

1. 尝试从现有托管 Git checkout 准备临时 checkout。
2. 设置请求的远端 locator。
3. Fetch 精确的远端 ref。
4. 以 detached 模式 checkout `FETCH_HEAD`。
5. 校验准备好的 source snapshot。
6. 原子替换托管 checkout。

如果本地准备失败，则继续使用既有的 clean clone、HTTPS fallback 和 archive fallback 流程。

当 `lock.originBranch` 存在时，远端预检、暂存 fetch、干净 clone 和 archive fallback 统一使用同一分支。干净下载完成后还会明确 fetch `refs/heads/<originBranch>`，确保最终 checkout 对应请求的分支，而不是同名 tag。

没有记录 `originBranch` 的 lock 继续使用既有的默认分支行为。

### 托管 checkout 所有权校验

在任何更新侧 checkout 操作之前，服务会验证：

- `lock.localPath` 与 `<stateRoot>/source/<sourceKind>/<sourceId>` 完全一致；
- 规范化路径仍位于托管 source root 内；
- source root、source kind 目录和 checkout 不是符号链接；
- realpath 解析结果仍位于真实的托管 source root 内。

路径不合法时返回 `SOURCE_CHECKOUT_PATH_INVALID`，并在读取或修改目标 checkout 之前终止。External source 会在托管 checkout 校验之前退出该更新路径。

### 感知 PID 的 mutation lock

Mutation lock 回收现在会判断持有进程的状态：

- 确认进程存活时保留锁；
- 确认进程已经退出时立即允许回收；
- owner 信息缺失或无法读取时使用既有的时间 stale 规则；
- 回收时先把锁 rename 到隔离路径，再执行删除。

这可以保证长时间更新仍然保持串行，同时避免已经失去 owner 的锁永久残留。

### 有上限的桌面更新

桌面 update 命令使用独立的执行时间预算：

- 明确选择 1 个来源：5 分钟；
- 2 个来源：10 分钟；
- 3 个或更多来源：15 分钟；
- Update All：15 分钟。

计算时间前会对 source ID 去重，同时显式处理整数溢出，最终结果始终不超过 15 分钟。

## 更新流程

```text
验证托管 checkout 所有权
  -> 读取 lock commit 和 branch
  -> 查询对应远端 ref
  -> 未变化时检查本地完整性并返回
  -> 已变化或无法确认时准备暂存 checkout
  -> 校验暂存 snapshot
  -> 原子替换托管 checkout
  -> 持久化更新后的 lock 和 inventory
```

普通来源 fetch 失败继续遵循既有的 partial-update 结果模型。托管路径不合法等 authority failure 会在 checkout 准备前终止。

## 验证

- `npm run build`
- `@skill-flow/integration`：`fs-utils.test.ts` — 6 项通过
- `@skill-flow/core-engine`：`source-checkout-service.test.ts` 与 `source-authority-service.test.ts` — 共 22 项通过
- `@skill-flow/query`：`source-lifecycle.test.ts` — 50 项通过
- Xcode 26.5 GitHub Actions 验证：更新专项测试、macOS production target 编译、release 打包和 artifact 校验均通过
