### PR TITLE
Recover interrupted macOS operations and prevent startup lockouts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,18 @@ _Avoid_: toast-on-every-enqueue, summary-only notifications
 The Group Operation Queue exists only for the current desktop app session. It is not written to Shared Skill State or Desktop Workspace Memory; quitting discards Queued work and does not auto-resume later.
 _Avoid_: durable download manager, restart resume
 
+**Quit Shutdown**:
+The desktop queue transition triggered by Command-Q or the application Quit menu while a Group Operation is Running. It rejects new operations, discards Queued work, and preserves the Running identity until cancellation and recovery finish. If the user cancels Quit after a recovery failure, protected operations stay disabled; a later successful recovery may reopen only a fresh empty session queue. Closing the main window does not trigger Quit Shutdown.
+_Avoid_: pause, resumable queue, general cancel action
+
+**Operation Recovery Journal**:
+Internal durable recovery evidence for the single incomplete managed Update or final Import. It records the pre-operation authority state and owned filesystem compensation data; it never records work to resume and is not Shared Skill State.
+_Avoid_: persisted queue, download history, migration marker
+
+**Recovery Required**:
+Desktop state after recovery failed and the user cancelled application termination. The main UI remains available, but Update and Import stay disabled; another Quit or Retry Recovery must attempt recovery again before termination can complete.
+_Avoid_: recovered, idle, ignore-and-quit
+
 **Bulk Update**:
 A single Group Operation that updates many installed groups in one bridge call (Home “Update All”). While it is Queued or Running, every covered group shows Card Operation Feedback; matching single-group Update entries already in the queue are absorbed so they are not run twice.
 _Avoid_: fan-out to N single updates, bypassing the queue

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,11 +77,11 @@ The desktop queue transition triggered by Command-Q or the application Quit menu
 _Avoid_: pause, resumable queue, general cancel action
 
 **Operation Recovery Journal**:
-Internal durable recovery evidence for the single incomplete managed Update or final Import. It records the pre-operation authority state and owned filesystem compensation data; it never records work to resume and is not Shared Skill State.
+Internal durable recovery evidence for the single incomplete managed Update or final Import. It records the pre-operation authority state plus explicit source, checkout, preparation, and target ownership metadata. Recovery validates the whole record against current managed roots before touching a recorded path; it never records work to resume and is not Shared Skill State.
 _Avoid_: persisted queue, download history, migration marker
 
 **Recovery Required**:
-Desktop state after recovery failed and the user cancelled application termination. The main UI remains available, but Update and Import stay disabled; another Quit or Retry Recovery must attempt recovery again before termination can complete.
+Desktop state after recovery failed and the user cancelled application termination. The main UI and import discovery (search, local scan, preview) remain available, but preparation, final Import, and Update stay disabled; another Quit or Retry Recovery must attempt recovery again before termination can complete.
 _Avoid_: recovered, idle, ignore-and-quit
 
 **Bulk Update**:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Installing skills one by one breaks down at scale:
 - **Multi-agent deployment**: deploy one selected skill set to Claude Code, Codex, Cursor, Grok Build, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, MiniMax Code, Kimi Code, WorkBuddy, CodeBuddy, Trae, Trae CN, Windsurf, ZCode, and more.
 - **Interactive config flow**: Ink-based TUI for add/config flows, selection state, review, and repair.
 - **Desktop app on macOS 15+**: SwiftUI main window, import view, detail panel, settings, and menu bar quick config.
+- **Safe desktop quit**: Command-Q cancels a running managed update/import, restores the incomplete group, and recovers interrupted work before the next launch continues.
 - **Explicit state**: `manifest.json` stores intent, `lock.json` stores resolved inventory and deployments.
 - **Bridge protocol**: machine-readable desktop/helper entrypoint via `skill-flow bridge --json`.
 - **Repair and diagnosis**: `doctor`, `repair-source`, `repair-state`, and `repair-targets` cover the parts that usually rot first.

--- a/README.zh.md
+++ b/README.zh.md
@@ -38,6 +38,7 @@
 - **多 agent 部署**：把同一组选中的 skill 部署到 Claude Code、Codex、Cursor、Grok Build、Gemini CLI、OpenCode、OpenClaw、Hermes Agent、MiniMax Code、Kimi Code、WorkBuddy、CodeBuddy、Trae、Trae CN、Windsurf、ZCode 等目标。
 - **交互式配置流程**：基于 Ink 的 add/config/find TUI，覆盖选择、审阅和修复流程。
 - **macOS 15+ 桌面应用**：SwiftUI 主窗口、导入页、详情页、设置页和菜单栏快速配置。
+- **安全退出桌面端**：按下 Command-Q 时会取消正在运行的托管更新/导入，恢复未完成的组，并在下次启动继续前先处理遗留恢复。
 - **显式状态**：`manifest.json` 记录意图，`lock.json` 记录实际 inventory 与 deployment。
 - **Bridge 协议**：通过 `skill-flow bridge --json` 提供机器可读入口。
 - **修复与诊断**：`doctor`、`repair-source`、`repair-state`、`repair-targets` 负责处理最容易坏掉的地方。

--- a/apps/desktop-mac/Sources/DesktopApp/App/DesktopAppContainer.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/App/DesktopAppContainer.swift
@@ -18,6 +18,7 @@ final class DesktopAppContainer {
     let detailContainer: DetailScreenContainer
     let homeContainer: HomeScreenContainer
     let navigation: RouteNavigation
+    let terminationCoordinator: ApplicationTerminationCoordinator
 
     init(
         runtime: DesktopRuntime? = nil,
@@ -117,6 +118,31 @@ final class DesktopAppContainer {
             settingsViewModel: settingsViewModel,
             importContainer: importContainer,
             detailContainer: detailContainer
+        )
+        self.terminationCoordinator = ApplicationTerminationCoordinator(
+            hasProtectedOperation: { [weak mainViewModel] in
+                mainViewModel?.hasActiveProtectedOperation ?? false
+            },
+            shutdownProtectedOperations: { [weak mainViewModel] in
+                mainViewModel?.shutdownProtectedOperationsForTermination()
+            },
+            cancelActiveHelper: { [weak bridgeClient] in
+                guard let bridgeClient else { return true }
+                return await bridgeClient.cancelActiveHelperForTermination()
+            },
+            recoverInterruptedOperation: { [weak bridgeClient] in
+                guard let bridgeClient else { return false }
+                do {
+                    _ = try await bridgeClient.bootstrap()
+                    return true
+                } catch {
+                    return false
+                }
+            },
+            resumeProtectedOperations: { [weak mainViewModel, weak bridgeClient] in
+                mainViewModel?.resumeProtectedOperationsAfterRecovery()
+                bridgeClient?.resumeProtectedOperationsAfterRecovery()
+            }
         )
         self.navigation = RouteNavigation(
             showHome: { [weak state = resolvedRuntime.state] in

--- a/apps/desktop-mac/Sources/DesktopApp/App/DesktopAppContainer.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/App/DesktopAppContainer.swift
@@ -123,6 +123,9 @@ final class DesktopAppContainer {
             hasProtectedOperation: { [weak mainViewModel] in
                 mainViewModel?.hasActiveProtectedOperation ?? false
             },
+            hasCancellableHelper: { [weak bridgeClient] in
+                bridgeClient?.hasActiveCancellableHelper ?? false
+            },
             shutdownProtectedOperations: { [weak mainViewModel] in
                 mainViewModel?.shutdownProtectedOperationsForTermination()
             },
@@ -139,9 +142,21 @@ final class DesktopAppContainer {
                     return false
                 }
             },
+            cleanupInterruptedDisposableWork: { [weak bridgeClient] in
+                guard let bridgeClient else { return false }
+                do {
+                    _ = try await bridgeClient.bootstrap()
+                    return true
+                } catch {
+                    return false
+                }
+            },
             resumeProtectedOperations: { [weak mainViewModel, weak bridgeClient] in
                 mainViewModel?.resumeProtectedOperationsAfterRecovery()
                 bridgeClient?.resumeProtectedOperationsAfterRecovery()
+            },
+            enterRecoveryRequiredState: { [weak bridgeClient] in
+                bridgeClient?.enterRecoveryRequiredState()
             }
         )
         self.navigation = RouteNavigation(

--- a/apps/desktop-mac/Sources/DesktopApp/App/SkillFlowDesktopApp.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/App/SkillFlowDesktopApp.swift
@@ -4,14 +4,21 @@ import SwiftUI
 @main
 struct SkillFlowDesktopApp: App {
     @Environment(\.openWindow) private var openWindow
+    @NSApplicationDelegateAdaptor(SkillFlowApplicationDelegate.self) private var appDelegate
 
     @State private var container = DesktopAppContainer()
 
     var body: some Scene {
         Window(L10n.string("app.name", locale: selectedLocale), id: "main-window") {
-            container.homeContainer.makeView()
-                .environment(\.locale, selectedLocale)
-                .background(WindowTitlebarConfigurator())
+            ZStack {
+                container.homeContainer.makeView()
+                TerminationStatusOverlay(coordinator: container.terminationCoordinator)
+            }
+            .environment(\.locale, selectedLocale)
+            .background(WindowTitlebarConfigurator())
+            .onAppear {
+                appDelegate.terminationCoordinator = container.terminationCoordinator
+            }
         }
         .windowStyle(.hiddenTitleBar)
 
@@ -50,6 +57,81 @@ struct SkillFlowDesktopApp: App {
     private var menuIcon: String {
         container.mainViewModel.healthStatus.menuIconSystemName
     }
+}
+
+@MainActor
+final class SkillFlowApplicationDelegate: NSObject, NSApplicationDelegate {
+    weak var terminationCoordinator: ApplicationTerminationCoordinator?
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard let terminationCoordinator else { return .terminateNow }
+        let disposition = terminationCoordinator.requestTermination { allowed in
+            sender.reply(toApplicationShouldTerminate: allowed)
+        }
+        if disposition == .terminateLater {
+            sender.activate(ignoringOtherApps: true)
+            sender.windows.first(where: { $0.canBecomeKey })?.makeKeyAndOrderFront(nil)
+        }
+        return disposition == .terminateNow ? .terminateNow : .terminateLater
+    }
+}
+
+private struct TerminationStatusOverlay: View {
+    let coordinator: ApplicationTerminationCoordinator
+
+    var body: some View {
+        if coordinator.phase == .recoveryRequired {
+            VStack {
+                HStack(spacing: 10) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text(L10n.string("termination.recovery_required", locale: locale))
+                        .font(.system(size: 13, weight: .semibold))
+                    Button(L10n.string("termination.retry", locale: locale)) {
+                        coordinator.retryRecovery()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding(10)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+                .shadow(radius: 12)
+                Spacer()
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if coordinator.phase != .idle {
+            ZStack {
+                Color.black.opacity(0.3).ignoresSafeArea()
+                VStack(spacing: 14) {
+                    if coordinator.phase == .stoppingAndRestoring {
+                        ProgressView()
+                        Text(L10n.string("termination.stopping", locale: locale))
+                            .font(.system(size: 15, weight: .semibold))
+                    } else {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text(L10n.string("termination.failed", locale: locale))
+                            .font(.system(size: 15, weight: .semibold))
+                        HStack {
+                            Button(L10n.string("termination.retry", locale: locale)) {
+                                coordinator.retryRecovery()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            Button(L10n.string("termination.cancel_exit", locale: locale)) {
+                                coordinator.cancelExit()
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    }
+                }
+                .padding(24)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+                .shadow(radius: 20)
+            }
+        }
+    }
+
+    @Environment(\.locale) private var locale
 }
 
 private struct WindowTitlebarConfigurator: NSViewRepresentable {

--- a/apps/desktop-mac/Sources/DesktopApp/Resources/en.lproj/Localizable.strings
+++ b/apps/desktop-mac/Sources/DesktopApp/Resources/en.lproj/Localizable.strings
@@ -419,6 +419,11 @@
 "settings.action.delete" = "Delete";
 "settings.action.close" = "Close";
 "settings.action.cancel" = "Cancel";
+"termination.stopping" = "Stopping the current operation and restoring its previous state…";
+"termination.failed" = "The operation could not be stopped safely. Skill Flow will remain open.";
+"termination.retry" = "Retry recovery";
+"termination.cancel_exit" = "Cancel exit";
+"termination.recovery_required" = "Recovery is still required. Updates and imports remain disabled.";
 "settings.action.save" = "Save";
 "settings.agent_details.title" = "Agent Details";
 "settings.agent_details.read_only_note" = "Built-in agents are read-only.";

--- a/apps/desktop-mac/Sources/DesktopApp/Resources/ja.lproj/Localizable.strings
+++ b/apps/desktop-mac/Sources/DesktopApp/Resources/ja.lproj/Localizable.strings
@@ -419,6 +419,11 @@
 "settings.action.delete" = "削除";
 "settings.action.close" = "閉じる";
 "settings.action.cancel" = "キャンセル";
+"termination.stopping" = "現在の操作を停止し、開始前の状態に復元しています…";
+"termination.failed" = "操作を安全に停止できませんでした。Skill Flow は実行を続けます。";
+"termination.retry" = "復元を再試行";
+"termination.cancel_exit" = "終了をキャンセル";
+"termination.recovery_required" = "復元が必要です。更新とインポートは引き続き無効です。";
 "settings.action.save" = "保存";
 "settings.agent_details.title" = "エージェント詳細";
 "settings.agent_details.read_only_note" = "組み込みエージェントは読み取り専用です。";

--- a/apps/desktop-mac/Sources/DesktopApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/desktop-mac/Sources/DesktopApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -419,6 +419,11 @@
 "settings.action.delete" = "删除";
 "settings.action.close" = "关闭";
 "settings.action.cancel" = "取消";
+"termination.stopping" = "正在中止当前操作并恢复到操作前状态……";
+"termination.failed" = "无法安全中止当前操作，Skill Flow 将保持运行。";
+"termination.retry" = "重试恢复";
+"termination.cancel_exit" = "取消退出";
+"termination.recovery_required" = "仍需完成恢复；更新和导入将保持禁用。";
 "settings.action.save" = "保存";
 "settings.agent_details.title" = "代理详情";
 "settings.agent_details.read_only_note" = "内置代理为只读。";

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/ApplicationTerminationCoordinator.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/ApplicationTerminationCoordinator.swift
@@ -19,31 +19,43 @@ final class ApplicationTerminationCoordinator {
     private(set) var phase: Phase = .idle
 
     private let hasProtectedOperation: () -> Bool
+    private let hasCancellableHelper: () -> Bool
     private let shutdownProtectedOperations: () -> Void
     private let cancelActiveHelper: () async -> Bool
     private let recoverInterruptedOperation: () async -> Bool
+    private let cleanupInterruptedDisposableWork: () async -> Bool
     private let resumeProtectedOperations: () -> Void
+    private let enterRecoveryRequiredState: () -> Void
     private var pendingReply: ((Bool) -> Void)?
     private var recoveryTask: Task<Void, Never>?
+    private var requiresDurableRecovery = false
 
     init(
         hasProtectedOperation: @escaping () -> Bool,
+        hasCancellableHelper: @escaping () -> Bool = { false },
         shutdownProtectedOperations: @escaping () -> Void,
         cancelActiveHelper: @escaping () async -> Bool,
         recoverInterruptedOperation: @escaping () async -> Bool,
-        resumeProtectedOperations: @escaping () -> Void = {}
+        cleanupInterruptedDisposableWork: @escaping () async -> Bool = { true },
+        resumeProtectedOperations: @escaping () -> Void = {},
+        enterRecoveryRequiredState: @escaping () -> Void = {}
     ) {
         self.hasProtectedOperation = hasProtectedOperation
+        self.hasCancellableHelper = hasCancellableHelper
         self.shutdownProtectedOperations = shutdownProtectedOperations
         self.cancelActiveHelper = cancelActiveHelper
         self.recoverInterruptedOperation = recoverInterruptedOperation
+        self.cleanupInterruptedDisposableWork = cleanupInterruptedDisposableWork
         self.resumeProtectedOperations = resumeProtectedOperations
+        self.enterRecoveryRequiredState = enterRecoveryRequiredState
     }
 
     func requestTermination(reply: @escaping (Bool) -> Void) -> Disposition {
-        guard hasProtectedOperation() || phase != .idle else { return .terminateNow }
+        let hasDurableWork = hasProtectedOperation()
+        guard hasDurableWork || hasCancellableHelper() || phase != .idle else { return .terminateNow }
         guard pendingReply == nil else { return .terminateLater }
 
+        requiresDurableRecovery = hasDurableWork || phase == .recoveryRequired || phase == .recoveryFailed
         pendingReply = reply
         shutdownProtectedOperations()
         beginRecoveryAttempt()
@@ -59,6 +71,7 @@ final class ApplicationTerminationCoordinator {
         recoveryTask?.cancel()
         recoveryTask = nil
         phase = .recoveryRequired
+        enterRecoveryRequiredState()
         let reply = pendingReply
         pendingReply = nil
         reply?(false)
@@ -72,7 +85,12 @@ final class ApplicationTerminationCoordinator {
             let cancelled = await cancelActiveHelper()
             let succeeded: Bool
             if cancelled {
-                succeeded = await recoverInterruptedOperation()
+                if requiresDurableRecovery {
+                    succeeded = await recoverInterruptedOperation()
+                } else {
+                    _ = await cleanupInterruptedDisposableWork()
+                    succeeded = true
+                }
             } else {
                 succeeded = false
             }

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/ApplicationTerminationCoordinator.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/ApplicationTerminationCoordinator.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ApplicationTerminationCoordinator {
+    enum Phase: Equatable {
+        case idle
+        case stoppingAndRestoring
+        case recoveryFailed
+        case recoveryRequired
+    }
+
+    enum Disposition: Equatable {
+        case terminateNow
+        case terminateLater
+    }
+
+    private(set) var phase: Phase = .idle
+
+    private let hasProtectedOperation: () -> Bool
+    private let shutdownProtectedOperations: () -> Void
+    private let cancelActiveHelper: () async -> Bool
+    private let recoverInterruptedOperation: () async -> Bool
+    private let resumeProtectedOperations: () -> Void
+    private var pendingReply: ((Bool) -> Void)?
+    private var recoveryTask: Task<Void, Never>?
+
+    init(
+        hasProtectedOperation: @escaping () -> Bool,
+        shutdownProtectedOperations: @escaping () -> Void,
+        cancelActiveHelper: @escaping () async -> Bool,
+        recoverInterruptedOperation: @escaping () async -> Bool,
+        resumeProtectedOperations: @escaping () -> Void = {}
+    ) {
+        self.hasProtectedOperation = hasProtectedOperation
+        self.shutdownProtectedOperations = shutdownProtectedOperations
+        self.cancelActiveHelper = cancelActiveHelper
+        self.recoverInterruptedOperation = recoverInterruptedOperation
+        self.resumeProtectedOperations = resumeProtectedOperations
+    }
+
+    func requestTermination(reply: @escaping (Bool) -> Void) -> Disposition {
+        guard hasProtectedOperation() || phase != .idle else { return .terminateNow }
+        guard pendingReply == nil else { return .terminateLater }
+
+        pendingReply = reply
+        shutdownProtectedOperations()
+        beginRecoveryAttempt()
+        return .terminateLater
+    }
+
+    func retryRecovery() {
+        guard phase == .recoveryFailed || phase == .recoveryRequired else { return }
+        beginRecoveryAttempt()
+    }
+
+    func cancelExit() {
+        recoveryTask?.cancel()
+        recoveryTask = nil
+        phase = .recoveryRequired
+        let reply = pendingReply
+        pendingReply = nil
+        reply?(false)
+    }
+
+    private func beginRecoveryAttempt() {
+        recoveryTask?.cancel()
+        phase = .stoppingAndRestoring
+        recoveryTask = Task { [weak self] in
+            guard let self else { return }
+            let cancelled = await cancelActiveHelper()
+            let succeeded: Bool
+            if cancelled {
+                succeeded = await recoverInterruptedOperation()
+            } else {
+                succeeded = false
+            }
+            guard !Task.isCancelled else { return }
+            if succeeded {
+                let shouldTerminate = pendingReply != nil
+                if !shouldTerminate {
+                    resumeProtectedOperations()
+                }
+                phase = .idle
+                let reply = pendingReply
+                pendingReply = nil
+                recoveryTask = nil
+                reply?(true)
+            } else {
+                phase = pendingReply == nil ? .recoveryRequired : .recoveryFailed
+                recoveryTask = nil
+            }
+        }
+    }
+}

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
@@ -105,12 +105,62 @@ final class BridgeClient: @unchecked Sendable {
         }
     }
 
+    private final class ActiveHelperRegistry: @unchecked Sendable {
+        private weak var process: Process?
+        private var command: BridgeCommand?
+        private var terminationCancellationRequested = false
+        private let lock = NSLock()
+
+        func set(_ process: Process, command: BridgeCommand) {
+            lock.lock()
+            self.process = process
+            self.command = command
+            lock.unlock()
+        }
+
+        func clear(ifMatching process: Process) {
+            lock.lock()
+            if self.process === process {
+                self.process = nil
+                self.command = nil
+            }
+            lock.unlock()
+        }
+
+        func requestTerminationCancellation() {
+            lock.lock()
+            terminationCancellationRequested = true
+            lock.unlock()
+        }
+
+        func clearTerminationCancellation() {
+            lock.lock()
+            terminationCancellationRequested = false
+            lock.unlock()
+        }
+
+        func shouldCancelBeforeLaunch(_ command: BridgeCommand) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return terminationCancellationRequested && command.isProtectedGroupOperation
+        }
+
+        func snapshot() -> (process: Process, command: BridgeCommand)? {
+            lock.lock()
+            defer { lock.unlock() }
+            guard let process, let command else { return nil }
+            return (process, command)
+        }
+    }
+
     private let mutationCoordinator = MutationCoordinator()
     private let commandTimeoutMilliseconds: UInt64
     private let importCommandTimeoutMilliseconds: UInt64
     private let updateSourceTimeoutMilliseconds: UInt64
     private let updateCommandMaximumTimeoutMilliseconds: UInt64
     private let commandTimeoutGraceMilliseconds: UInt64
+    private let quitCancellationGraceMilliseconds: UInt64
+    private let activeHelper = ActiveHelperRegistry()
 
     init(
         commandTimeoutMilliseconds: UInt64 = 60_000,
@@ -119,13 +169,15 @@ final class BridgeClient: @unchecked Sendable {
         // One source receives five minutes; selected updates scale to a 15-minute ceiling.
         updateSourceTimeoutMilliseconds: UInt64 = 300_000,
         updateCommandMaximumTimeoutMilliseconds: UInt64 = 900_000,
-        commandTimeoutGraceMilliseconds: UInt64 = 1_000
+        commandTimeoutGraceMilliseconds: UInt64 = 1_000,
+        quitCancellationGraceMilliseconds: UInt64 = 5_000
     ) {
         self.commandTimeoutMilliseconds = commandTimeoutMilliseconds
         self.importCommandTimeoutMilliseconds = importCommandTimeoutMilliseconds
         self.updateSourceTimeoutMilliseconds = updateSourceTimeoutMilliseconds
         self.updateCommandMaximumTimeoutMilliseconds = updateCommandMaximumTimeoutMilliseconds
         self.commandTimeoutGraceMilliseconds = commandTimeoutGraceMilliseconds
+        self.quitCancellationGraceMilliseconds = quitCancellationGraceMilliseconds
     }
 
     func bootstrap() async throws -> BridgeResponse {
@@ -381,6 +433,9 @@ final class BridgeClient: @unchecked Sendable {
     }
 
     private func send(command: BridgeCommand, payload: [String: AnyCodable]? = nil) async throws -> BridgeResponse {
+        if activeHelper.shouldCancelBeforeLaunch(command) {
+            throw BridgeClientError.commandFailed("Protected operation cancelled because Skill Flow is terminating.")
+        }
         let helperURL = try resolveHelperURL()
         let request = BridgeRequest(command: command, payload: payload)
         let requestData = try JSONEncoder().encode(request)
@@ -394,13 +449,11 @@ final class BridgeClient: @unchecked Sendable {
         )
 
         let process = Process()
-        if nodeExecutable == "node" {
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = ["node", helperURL.path, "bridge", "--json"]
-        } else {
-            process.executableURL = URL(fileURLWithPath: nodeExecutable)
-            process.arguments = [helperURL.path, "bridge", "--json"]
-        }
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        let helperArguments = nodeExecutable == "node"
+            ? ["/usr/bin/env", "node", helperURL.path, "bridge", "--json"]
+            : [nodeExecutable, helperURL.path, "bridge", "--json"]
+        process.arguments = ["-c", Self.processGroupLauncherScript, "skill-flow-helper"] + helperArguments
         process.environment = Self.bridgeEnvironment(bundledNodeBinDirectory: bundledNodeBinDirectory)
 
         let inputPipe = Pipe()
@@ -429,6 +482,8 @@ final class BridgeClient: @unchecked Sendable {
         }
 
         try process.run()
+        activeHelper.set(process, command: command)
+        defer { activeHelper.clear(ifMatching: process) }
         inputPipe.fileHandleForWriting.write(requestData)
         inputPipe.fileHandleForWriting.closeFile()
 
@@ -544,33 +599,64 @@ final class BridgeClient: @unchecked Sendable {
     }
 
     private func terminateTimedOutProcess(_ process: Process) async {
-        let state = ProcessExitWaitState()
-        process.terminationHandler = { _ in
-            state.resolve(.exited)
+        _ = await terminateManagedHelper(process, graceMilliseconds: commandTimeoutGraceMilliseconds)
+    }
+
+    /// Cancels the helper serving the currently running protected desktop
+    /// operation. The shell wrapper owns a dedicated helper process group: TERM
+    /// is forwarded cooperatively, then USR1 makes the wrapper SIGKILL that
+    /// entire group after the quit grace period.
+    func cancelActiveHelperForTermination() async -> Bool {
+        activeHelper.requestTerminationCancellation()
+        guard let active = activeHelper.snapshot(), active.process.isRunning else { return true }
+        if active.command.isProtectedGroupOperation {
+            return await terminateManagedHelper(
+                active.process,
+                graceMilliseconds: quitCancellationGraceMilliseconds
+            )
         }
 
-        process.terminate()
-
-        let didExitAfterTerminate = await waitForProcessExit(
-            process,
-            state: state,
-            timeoutMilliseconds: commandTimeoutGraceMilliseconds
-        )
-        guard !didExitAfterTerminate, process.isRunning else {
-            return
-        }
-
-        let killState = ProcessExitWaitState()
-        process.terminationHandler = { _ in
-            killState.resolve(.exited)
-        }
-        kill(process.processIdentifier, SIGKILL)
-        _ = await waitForProcessExit(
-            process,
-            state: killState,
-            timeoutMilliseconds: commandTimeoutGraceMilliseconds
+        // A short non-protected mutation already owns the serial channel. Let
+        // it finish normally; the termination latch prevents the queued group
+        // operation from launching afterward.
+        return await waitUntilStopped(
+            active.process,
+            timeoutMilliseconds: commandTimeoutMilliseconds + commandTimeoutGraceMilliseconds
         )
     }
+
+    func resumeProtectedOperationsAfterRecovery() {
+        activeHelper.clearTerminationCancellation()
+    }
+
+    private func terminateManagedHelper(_ process: Process, graceMilliseconds: UInt64) async -> Bool {
+        guard process.isRunning else { return true }
+        process.terminate()
+        if await waitUntilStopped(process, timeoutMilliseconds: graceMilliseconds) { return true }
+        guard process.isRunning else { return true }
+        kill(process.processIdentifier, SIGUSR1)
+        return await waitUntilStopped(process, timeoutMilliseconds: commandTimeoutGraceMilliseconds)
+    }
+
+    private func waitUntilStopped(_ process: Process, timeoutMilliseconds: UInt64) async -> Bool {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutMilliseconds) / 1_000)
+        while process.isRunning, Date() < deadline {
+            try? await Task.sleep(nanoseconds: min(Self.nanoseconds(fromMilliseconds: 10), Self.nanoseconds(fromMilliseconds: timeoutMilliseconds)))
+        }
+        return !process.isRunning
+    }
+
+    private static let processGroupLauncherScript = #"""
+    set -m
+    "$@" <&0 &
+    child=$!
+    trap 'kill -TERM -$child 2>/dev/null; wait "$child"' TERM
+    trap 'kill -KILL -$child 2>/dev/null; exit 137' USR1
+    wait "$child"
+    status=$?
+    trap - TERM USR1
+    exit "$status"
+    """#
 
     private static func nanoseconds(fromMilliseconds milliseconds: UInt64) -> UInt64 {
         let (nanoseconds, overflow) = milliseconds.multipliedReportingOverflow(by: 1_000_000)

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
@@ -691,7 +691,12 @@ final class BridgeClient: @unchecked Sendable {
     "$@" <&0 &
     child=$!
     trap 'kill -TERM "$child" 2>/dev/null; wait "$child"' TERM
-    trap 'kill -TERM -$child 2>/dev/null; wait "$child"' INT
+    wait_for_group() {
+      while kill -0 -$child 2>/dev/null; do
+        sleep 0.05
+      done
+    }
+    trap 'kill -TERM -$child 2>/dev/null; wait "$child"; wait_for_group' INT
     trap 'kill -KILL "$child" 2>/dev/null; exit 137' USR2
     trap 'kill -KILL -$child 2>/dev/null; exit 137' USR1
     wait "$child"

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
@@ -657,10 +657,6 @@ final class BridgeClient: @unchecked Sendable {
         activeHelper.clearTerminationCancellation()
     }
 
-    private func terminateManagedHelper(_ process: Process, graceMilliseconds: UInt64) async -> Bool {
-        await terminateProcessGroups([process], graceMilliseconds: graceMilliseconds)
-    }
-
     private func terminateProcessGroups(_ processes: [Process], graceMilliseconds: UInt64) async -> Bool {
         let running = processes.filter(\.isRunning)
         guard !running.isEmpty else { return true }

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
@@ -481,7 +481,11 @@ final class BridgeClient: @unchecked Sendable {
             ? ["/usr/bin/env", "node", helperURL.path, "bridge", "--json"]
             : [nodeExecutable, helperURL.path, "bridge", "--json"]
         process.arguments = ["-c", Self.processGroupLauncherScript, "skill-flow-helper"] + helperArguments
-        process.environment = Self.bridgeEnvironment(bundledNodeBinDirectory: bundledNodeBinDirectory)
+        var environment = Self.bridgeEnvironment(bundledNodeBinDirectory: bundledNodeBinDirectory)
+        environment["SKILL_FLOW_HELPER_TIMEOUT_GRACE_SECONDS"] = String(
+            Double(commandTimeoutGraceMilliseconds) / 1_000
+        )
+        process.environment = environment
 
         let inputPipe = Pipe()
         let outputPipe = Pipe()
@@ -686,7 +690,14 @@ final class BridgeClient: @unchecked Sendable {
     set -m
     "$@" <&0 &
     child=$!
-    trap 'kill -TERM "$child" 2>/dev/null; wait "$child"' TERM
+    terminate_child_after_timeout_grace() {
+      kill -TERM "$child" 2>/dev/null
+      (
+        sleep "${SKILL_FLOW_HELPER_TIMEOUT_GRACE_SECONDS:-1}"
+        kill -KILL "$child" 2>/dev/null
+      ) &
+    }
+    trap 'terminate_child_after_timeout_grace' TERM
     wait_for_group() {
       while kill -0 -$child 2>/dev/null; do
         sleep 0.05

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Bridge/BridgeClient.swift
@@ -106,50 +106,89 @@ final class BridgeClient: @unchecked Sendable {
     }
 
     private final class ActiveHelperRegistry: @unchecked Sendable {
-        private weak var process: Process?
-        private var command: BridgeCommand?
-        private var terminationCancellationRequested = false
+        private enum Mode {
+            case normal
+            case terminating
+            case recoveryRequired
+        }
+
+        private struct Entry {
+            let process: Process
+            let command: BridgeCommand
+        }
+
+        private var entries: [ObjectIdentifier: Entry] = [:]
+        private var mode: Mode = .normal
         private let lock = NSLock()
 
-        func set(_ process: Process, command: BridgeCommand) {
+        func run(_ process: Process, command: BridgeCommand) throws {
             lock.lock()
-            self.process = process
-            self.command = command
-            lock.unlock()
+            defer { lock.unlock() }
+            if shouldCancelBeforeLaunchLocked(command) {
+                throw BridgeClientError.commandFailed("Operation cancelled because Skill Flow is terminating.")
+            }
+            try process.run()
+            entries[ObjectIdentifier(process)] = Entry(process: process, command: command)
         }
 
         func clear(ifMatching process: Process) {
             lock.lock()
-            if self.process === process {
-                self.process = nil
-                self.command = nil
-            }
+            entries.removeValue(forKey: ObjectIdentifier(process))
             lock.unlock()
         }
 
         func requestTerminationCancellation() {
             lock.lock()
-            terminationCancellationRequested = true
+            mode = .terminating
             lock.unlock()
         }
 
         func clearTerminationCancellation() {
             lock.lock()
-            terminationCancellationRequested = false
+            mode = .normal
+            lock.unlock()
+        }
+
+        func markRecoveryRequired() {
+            lock.lock()
+            mode = .recoveryRequired
             lock.unlock()
         }
 
         func shouldCancelBeforeLaunch(_ command: BridgeCommand) -> Bool {
             lock.lock()
             defer { lock.unlock() }
-            return terminationCancellationRequested && command.isProtectedGroupOperation
+            return shouldCancelBeforeLaunchLocked(command)
         }
 
-        func snapshot() -> (process: Process, command: BridgeCommand)? {
+        private func shouldCancelBeforeLaunchLocked(_ command: BridgeCommand) -> Bool {
+            switch mode {
+            case .normal:
+                return false
+            case .terminating:
+                return command.helperTerminationRole.isCancellableOnQuit
+            case .recoveryRequired:
+                return !command.helperTerminationRole.isAllowedDuringRecoveryRequired
+            }
+        }
+
+        func hasCancellableHelpers() -> Bool {
             lock.lock()
             defer { lock.unlock() }
-            guard let process, let command else { return nil }
-            return (process, command)
+            return entries.values.contains { entry in
+                entry.process.isRunning && entry.command.helperTerminationRole.isCancellableOnQuit
+            }
+        }
+
+        func cancellableProcesses() -> [Process] {
+            lock.lock()
+            defer { lock.unlock() }
+            return entries.values.compactMap { entry in
+                guard entry.process.isRunning, entry.command.helperTerminationRole.isCancellableOnQuit else {
+                    return nil
+                }
+                return entry.process
+            }
         }
     }
 
@@ -269,14 +308,21 @@ final class BridgeClient: @unchecked Sendable {
         enabledTargets: [String],
         skillSelectionMode: ImportSkillSelectionMode = .selected
     ) async throws -> BridgeResponse {
-        try await mutationCoordinator.runMutation {
-            try await self.sendImportSourceDraft(
-                locator: locator,
-                selectedSkills: selectedSkills,
-                enabledTargets: enabledTargets,
-                skillSelectionMode: skillSelectionMode
-            )
+        let prepared = try await prepareImportSource(locator: locator)
+        guard
+            let payload = prepared.data?.value as? [String: Any],
+            payload["status"] as? String == "ready",
+            let preparationId = payload["preparationId"] as? String,
+            !preparationId.isEmpty
+        else {
+            throw BridgeClientError.commandFailed("Import preparation did not produce a committable source.")
         }
+        return try await commitImportSource(
+            preparationId: preparationId,
+            selectedSkills: selectedSkills,
+            enabledTargets: enabledTargets,
+            skillSelectionMode: skillSelectionMode
+        )
     }
 
     private func sendCommitImportSourceDraft(
@@ -289,25 +335,6 @@ final class BridgeClient: @unchecked Sendable {
             command: .commitImportSource,
             payload: [
                 "preparationId": AnyCodable(preparationId),
-                "draft": AnyCodable([
-                    "skillSelectionMode": skillSelectionMode.rawValue,
-                    "selectedSkills": selectedSkills.map(\.bridgePayload),
-                    "enabledTargets": enabledTargets,
-                ]),
-            ]
-        )
-    }
-
-    private func sendImportSourceDraft(
-        locator: String,
-        selectedSkills: [ImportSkillSelection],
-        enabledTargets: [String],
-        skillSelectionMode: ImportSkillSelectionMode
-    ) async throws -> BridgeResponse {
-        try await send(
-            command: .importSource,
-            payload: [
-                "locator": AnyCodable(locator),
                 "draft": AnyCodable([
                     "skillSelectionMode": skillSelectionMode.rawValue,
                     "selectedSkills": selectedSkills.map(\.bridgePayload),
@@ -481,8 +508,7 @@ final class BridgeClient: @unchecked Sendable {
             errorBuffer.append(chunk)
         }
 
-        try process.run()
-        activeHelper.set(process, command: command)
+        try activeHelper.run(process, command: command)
         defer { activeHelper.clear(ifMatching: process) }
         inputPipe.fileHandleForWriting.write(requestData)
         inputPipe.fileHandleForWriting.closeFile()
@@ -599,7 +625,12 @@ final class BridgeClient: @unchecked Sendable {
     }
 
     private func terminateTimedOutProcess(_ process: Process) async {
-        _ = await terminateManagedHelper(process, graceMilliseconds: commandTimeoutGraceMilliseconds)
+        guard process.isRunning else { return }
+        process.terminate()
+        if await waitUntilStopped(process, timeoutMilliseconds: commandTimeoutGraceMilliseconds) { return }
+        guard process.isRunning else { return }
+        kill(process.processIdentifier, SIGUSR2)
+        _ = await waitUntilStopped(process, timeoutMilliseconds: commandTimeoutGraceMilliseconds)
     }
 
     /// Cancels the helper serving the currently running protected desktop
@@ -608,21 +639,18 @@ final class BridgeClient: @unchecked Sendable {
     /// entire group after the quit grace period.
     func cancelActiveHelperForTermination() async -> Bool {
         activeHelper.requestTerminationCancellation()
-        guard let active = activeHelper.snapshot(), active.process.isRunning else { return true }
-        if active.command.isProtectedGroupOperation {
-            return await terminateManagedHelper(
-                active.process,
-                graceMilliseconds: quitCancellationGraceMilliseconds
-            )
-        }
-
-        // A short non-protected mutation already owns the serial channel. Let
-        // it finish normally; the termination latch prevents the queued group
-        // operation from launching afterward.
-        return await waitUntilStopped(
-            active.process,
-            timeoutMilliseconds: commandTimeoutMilliseconds + commandTimeoutGraceMilliseconds
+        return await terminateProcessGroups(
+            activeHelper.cancellableProcesses(),
+            graceMilliseconds: quitCancellationGraceMilliseconds
         )
+    }
+
+    var hasActiveCancellableHelper: Bool {
+        activeHelper.hasCancellableHelpers()
+    }
+
+    func enterRecoveryRequiredState() {
+        activeHelper.markRecoveryRequired()
     }
 
     func resumeProtectedOperationsAfterRecovery() {
@@ -630,27 +658,41 @@ final class BridgeClient: @unchecked Sendable {
     }
 
     private func terminateManagedHelper(_ process: Process, graceMilliseconds: UInt64) async -> Bool {
-        guard process.isRunning else { return true }
-        process.terminate()
-        if await waitUntilStopped(process, timeoutMilliseconds: graceMilliseconds) { return true }
-        guard process.isRunning else { return true }
-        kill(process.processIdentifier, SIGUSR1)
-        return await waitUntilStopped(process, timeoutMilliseconds: commandTimeoutGraceMilliseconds)
+        await terminateProcessGroups([process], graceMilliseconds: graceMilliseconds)
+    }
+
+    private func terminateProcessGroups(_ processes: [Process], graceMilliseconds: UInt64) async -> Bool {
+        let running = processes.filter(\.isRunning)
+        guard !running.isEmpty else { return true }
+        for process in running {
+            kill(process.processIdentifier, SIGINT)
+        }
+        if await waitUntilAllStopped(running, timeoutMilliseconds: graceMilliseconds) { return true }
+        for process in running where process.isRunning {
+            kill(process.processIdentifier, SIGUSR1)
+        }
+        return await waitUntilAllStopped(running, timeoutMilliseconds: commandTimeoutGraceMilliseconds)
     }
 
     private func waitUntilStopped(_ process: Process, timeoutMilliseconds: UInt64) async -> Bool {
+        await waitUntilAllStopped([process], timeoutMilliseconds: timeoutMilliseconds)
+    }
+
+    private func waitUntilAllStopped(_ processes: [Process], timeoutMilliseconds: UInt64) async -> Bool {
         let deadline = Date().addingTimeInterval(TimeInterval(timeoutMilliseconds) / 1_000)
-        while process.isRunning, Date() < deadline {
+        while processes.contains(where: \.isRunning), Date() < deadline {
             try? await Task.sleep(nanoseconds: min(Self.nanoseconds(fromMilliseconds: 10), Self.nanoseconds(fromMilliseconds: timeoutMilliseconds)))
         }
-        return !process.isRunning
+        return !processes.contains(where: \.isRunning)
     }
 
     private static let processGroupLauncherScript = #"""
     set -m
     "$@" <&0 &
     child=$!
-    trap 'kill -TERM -$child 2>/dev/null; wait "$child"' TERM
+    trap 'kill -TERM "$child" 2>/dev/null; wait "$child"' TERM
+    trap 'kill -TERM -$child 2>/dev/null; wait "$child"' INT
+    trap 'kill -KILL "$child" 2>/dev/null; exit 137' USR2
     trap 'kill -KILL -$child 2>/dev/null; exit 137' USR1
     wait "$child"
     status=$?

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/GroupOperationCoordinator.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/GroupOperationCoordinator.swift
@@ -35,6 +35,10 @@ final class GroupOperationCoordinator {
     private(set) var updatePhases: [String: GroupOperationQueue.Phase] = [:]
     private(set) var importPhases: [String: GroupOperationQueue.Phase] = [:]
 
+    var activeProtectedOperation: GroupOperationQueue.Operation? {
+        queue.runningOperation
+    }
+
     var importingImportGroupId: String? {
         queue.runningImportGroupId
             ?? testingImportPhaseOverrides.first(where: { $0.value == .running })?.key
@@ -88,6 +92,8 @@ final class GroupOperationCoordinator {
         switch queue.enqueueUpdate(sourceId: normalized) {
         case .alreadyPresent:
             hosts?.onAlreadyQueued()
+        case .shutDown:
+            return
         case .enqueued:
             publishPhases()
             await drain()
@@ -98,6 +104,8 @@ final class GroupOperationCoordinator {
         switch queue.enqueueBulkUpdate(sourceIds: sourceIds) {
         case .alreadyPresent:
             hosts?.onAlreadyQueued()
+        case .shutDown:
+            return
         case .enqueued:
             publishPhases()
             await drain()
@@ -118,6 +126,8 @@ final class GroupOperationCoordinator {
         switch queue.enqueueImport(groupId: normalized) {
         case .alreadyPresent:
             hosts?.onAlreadyQueued()
+        case .shutDown:
+            return
         case .enqueued:
             pendingImportRequestsByGroupId[normalized] = PendingImportRequest(
                 locator: locator,
@@ -128,6 +138,21 @@ final class GroupOperationCoordinator {
             publishPhases()
             await drain()
         }
+    }
+
+    /// Freezes the session queue and returns the operation whose bridge helper
+    /// must be cancelled before AppKit may finish terminating.
+    @discardableResult
+    func shutdownForTermination() -> GroupOperationQueue.Operation? {
+        let active = queue.shutdown()
+        pendingImportRequestsByGroupId.removeAll()
+        publishPhases()
+        return active
+    }
+
+    func resumeAfterRecovery() {
+        queue.resumeAfterRecovery()
+        publishPhases()
     }
 
     private func drain() async {

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/GroupOperationQueue.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/GroupOperationQueue.swift
@@ -17,6 +17,7 @@ final class GroupOperationQueue {
     enum EnqueueOutcome: Equatable, Sendable {
         case enqueued
         case alreadyPresent
+        case shutDown
     }
 
     private struct Entry: Equatable {
@@ -25,8 +26,10 @@ final class GroupOperationQueue {
     }
 
     private var entries: [Entry] = []
+    private var isShutDown = false
 
     func enqueueUpdate(sourceId: String) -> EnqueueOutcome {
+        guard !isShutDown else { return .shutDown }
         let normalized = Self.normalize(sourceId)
         guard !normalized.isEmpty else {
             return .alreadyPresent
@@ -41,6 +44,7 @@ final class GroupOperationQueue {
     }
 
     func enqueueBulkUpdate(sourceIds: [String]) -> EnqueueOutcome {
+        guard !isShutDown else { return .shutDown }
         let normalized = Self.normalizeList(sourceIds)
         guard !normalized.isEmpty else {
             return .alreadyPresent
@@ -71,6 +75,7 @@ final class GroupOperationQueue {
     }
 
     func enqueueImport(groupId: String) -> EnqueueOutcome {
+        guard !isShutDown else { return .shutDown }
         let normalized = Self.normalize(groupId)
         guard !normalized.isEmpty else {
             return .alreadyPresent
@@ -85,6 +90,7 @@ final class GroupOperationQueue {
     }
 
     func startNext() -> Operation? {
+        guard !isShutDown else { return nil }
         guard !entries.contains(where: { $0.phase == .running }) else {
             return nil
         }
@@ -99,12 +105,36 @@ final class GroupOperationQueue {
         entries.removeAll { $0.phase == .running }
     }
 
+    /// Permanently freezes this session queue, discards work that has not
+    /// started, and returns the protected operation currently in flight.
+    @discardableResult
+    func shutdown() -> Operation? {
+        isShutDown = true
+        let running = entries.first(where: { $0.phase == .running })?.operation
+        entries.removeAll { $0.phase == .queued }
+        return running
+    }
+
+    /// Starts a fresh empty session queue after an interrupted operation has
+    /// been recovered and the user chose to keep the application open.
+    func resumeAfterRecovery() {
+        // Recovery is the commit point for abandoning the interrupted session.
+        // Its original async drain may not have delivered completeRunning yet,
+        // so remove that stale identity here rather than leaving the queue shut.
+        entries.removeAll()
+        isShutDown = false
+    }
+
     var hasQueuedWork: Bool {
         entries.contains { $0.phase == .queued }
     }
 
     var hasWork: Bool {
         !entries.isEmpty
+    }
+
+    var runningOperation: Operation? {
+        entries.first(where: { $0.phase == .running })?.operation
     }
 
     func updatePhase(for sourceId: String) -> Phase? {

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Models/BridgeProtocol.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Models/BridgeProtocol.swift
@@ -30,17 +30,40 @@ enum BridgeCommand: String, Codable, Sendable, CaseIterable {
     case saveSettings = "save-settings"
 }
 
+enum BridgeHelperTerminationRole: Sendable, Equatable {
+    case durableMutation
+    case preparation
+    case disposableQuery
+    case unrelated
+
+    var isCancellableOnQuit: Bool {
+        self != .unrelated
+    }
+
+    var isAllowedDuringRecoveryRequired: Bool {
+        self == .disposableQuery || self == .unrelated
+    }
+}
+
 extension BridgeCommand {
     var isProtectedGroupOperation: Bool {
+        helperTerminationRole == .durableMutation
+    }
+
+    var helperTerminationRole: BridgeHelperTerminationRole {
         switch self {
-        case .prepareImportSource,
-             .previewImportSource,
-             .commitImportSource,
+        case .commitImportSource,
              .importSource,
              .update:
-            return true
+            return .durableMutation
+        case .prepareImportSource:
+            return .preparation
+        case .searchImportGroups,
+             .scanLocalImportGroups,
+             .previewImportSource:
+            return .disposableQuery
         default:
-            return false
+            return .unrelated
         }
     }
 

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Models/BridgeProtocol.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Models/BridgeProtocol.swift
@@ -46,10 +46,6 @@ enum BridgeHelperTerminationRole: Sendable, Equatable {
 }
 
 extension BridgeCommand {
-    var isProtectedGroupOperation: Bool {
-        helperTerminationRole == .durableMutation
-    }
-
     var helperTerminationRole: BridgeHelperTerminationRole {
         switch self {
         case .commitImportSource,

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Models/BridgeProtocol.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Models/BridgeProtocol.swift
@@ -102,11 +102,6 @@ extension BridgeCommand {
             return false
         }
     }
-
-    @available(*, deprecated, renamed: "usesExtendedNetworkTimeout")
-    var usesImportTimeout: Bool {
-        usesExtendedNetworkTimeout
-    }
 }
 
 struct BridgeRequest: Codable, Sendable {

--- a/apps/desktop-mac/Sources/DesktopApp/Runtime/Models/BridgeProtocol.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Runtime/Models/BridgeProtocol.swift
@@ -31,6 +31,19 @@ enum BridgeCommand: String, Codable, Sendable, CaseIterable {
 }
 
 extension BridgeCommand {
+    var isProtectedGroupOperation: Bool {
+        switch self {
+        case .prepareImportSource,
+             .previewImportSource,
+             .commitImportSource,
+             .importSource,
+             .update:
+            return true
+        default:
+            return false
+        }
+    }
+
     /// Longer bridge helper budget for network-heavy work (import, update, add).
     /// Ordinary UI mutations keep the shorter default command timeout.
     var usesExtendedNetworkTimeout: Bool {

--- a/apps/desktop-mac/Sources/DesktopApp/ViewModels/MainViewModel.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/ViewModels/MainViewModel.swift
@@ -187,6 +187,18 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
     private(set) var updateOperationPhases: [String: GroupOperationQueue.Phase] = [:]
     private(set) var importOperationPhases: [String: GroupOperationQueue.Phase] = [:]
 
+    var hasActiveProtectedOperation: Bool {
+        groupOperations.activeProtectedOperation != nil
+    }
+
+    func shutdownProtectedOperationsForTermination() {
+        groupOperations.shutdownForTermination()
+    }
+
+    func resumeProtectedOperationsAfterRecovery() {
+        groupOperations.resumeAfterRecovery()
+    }
+
     var loadState: LoadState { stateManager.loadState }
     var selectedSection: Section { stateManager.selectedSection }
     var sourceIds: [String] {

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/ApplicationTerminationCoordinatorTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/ApplicationTerminationCoordinatorTests.swift
@@ -16,6 +16,34 @@ final class ApplicationTerminationCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.phase, .idle)
     }
 
+    func testDisposableHelperDelaysQuitForCancellationButCleanupFailureDoesNotBlockExit() async {
+        var didShutdown = false
+        var didAttemptCleanup = false
+        var reply: Bool?
+        let coordinator = ApplicationTerminationCoordinator(
+            hasProtectedOperation: { false },
+            hasCancellableHelper: { true },
+            shutdownProtectedOperations: { didShutdown = true },
+            cancelActiveHelper: { true },
+            recoverInterruptedOperation: {
+                XCTFail("Disposable-only termination must not require durable recovery.")
+                return false
+            },
+            cleanupInterruptedDisposableWork: {
+                didAttemptCleanup = true
+                return false
+            }
+        )
+
+        XCTAssertEqual(coordinator.requestTermination { reply = $0 }, .terminateLater)
+        XCTAssertTrue(didShutdown)
+        await waitUntil { reply != nil }
+
+        XCTAssertTrue(didAttemptCleanup)
+        XCTAssertEqual(reply, true)
+        XCTAssertEqual(coordinator.phase, .idle)
+    }
+
     func testProtectedTerminationStopsQueueAndRepliesAfterCancellationSucceeds() async {
         var didShutdown = false
         var reply: Bool?
@@ -96,13 +124,15 @@ final class ApplicationTerminationCoordinatorTests: XCTestCase {
     func testSuccessfulRetryAfterCancellingExitResumesProtectedOperations() async {
         var recoverySucceeds = false
         var didResume = false
+        var didEnterRecoveryRequired = false
         var reply: Bool?
         let coordinator = ApplicationTerminationCoordinator(
             hasProtectedOperation: { true },
             shutdownProtectedOperations: {},
             cancelActiveHelper: { true },
             recoverInterruptedOperation: { recoverySucceeds },
-            resumeProtectedOperations: { didResume = true }
+            resumeProtectedOperations: { didResume = true },
+            enterRecoveryRequiredState: { didEnterRecoveryRequired = true }
         )
 
         XCTAssertEqual(coordinator.requestTermination { reply = $0 }, .terminateLater)
@@ -110,6 +140,7 @@ final class ApplicationTerminationCoordinatorTests: XCTestCase {
         coordinator.cancelExit()
         XCTAssertEqual(reply, false)
         XCTAssertEqual(coordinator.phase, .recoveryRequired)
+        XCTAssertTrue(didEnterRecoveryRequired)
 
         recoverySucceeds = true
         coordinator.retryRecovery()

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/ApplicationTerminationCoordinatorTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/ApplicationTerminationCoordinatorTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+
+@testable import SkillFlowDesktop
+
+@MainActor
+final class ApplicationTerminationCoordinatorTests: XCTestCase {
+    func testTerminationIsImmediateWithoutProtectedWork() {
+        let coordinator = ApplicationTerminationCoordinator(
+            hasProtectedOperation: { false },
+            shutdownProtectedOperations: {},
+            cancelActiveHelper: { true },
+            recoverInterruptedOperation: { true }
+        )
+
+        XCTAssertEqual(coordinator.requestTermination(reply: { _ in }), .terminateNow)
+        XCTAssertEqual(coordinator.phase, .idle)
+    }
+
+    func testProtectedTerminationStopsQueueAndRepliesAfterCancellationSucceeds() async {
+        var didShutdown = false
+        var reply: Bool?
+        let coordinator = ApplicationTerminationCoordinator(
+            hasProtectedOperation: { true },
+            shutdownProtectedOperations: { didShutdown = true },
+            cancelActiveHelper: { true },
+            recoverInterruptedOperation: { true }
+        )
+
+        XCTAssertEqual(coordinator.requestTermination { reply = $0 }, .terminateLater)
+        XCTAssertTrue(didShutdown)
+        XCTAssertEqual(coordinator.phase, .stoppingAndRestoring)
+
+        await waitUntil { reply != nil }
+        XCTAssertEqual(reply, true)
+        XCTAssertEqual(coordinator.phase, .idle)
+    }
+
+    func testFailedCancellationBlocksQuitAndSupportsRetryOrCancelExit() async {
+        var attempts = 0
+        var reply: Bool?
+        let coordinator = ApplicationTerminationCoordinator(
+            hasProtectedOperation: { true },
+            shutdownProtectedOperations: {},
+            cancelActiveHelper: {
+                attempts += 1
+                return attempts > 1
+            },
+            recoverInterruptedOperation: { true }
+        )
+
+        XCTAssertEqual(coordinator.requestTermination { reply = $0 }, .terminateLater)
+        await waitUntil { coordinator.phase == .recoveryFailed }
+        XCTAssertNil(reply)
+
+        coordinator.retryRecovery()
+        await waitUntil { reply != nil }
+        XCTAssertEqual(reply, true)
+
+        reply = nil
+        attempts = 0
+        var hasProtectedOperation = true
+        let cancelled = ApplicationTerminationCoordinator(
+            hasProtectedOperation: { hasProtectedOperation },
+            shutdownProtectedOperations: {},
+            cancelActiveHelper: { false },
+            recoverInterruptedOperation: { true }
+        )
+        XCTAssertEqual(cancelled.requestTermination { reply = $0 }, .terminateLater)
+        await waitUntil { cancelled.phase == .recoveryFailed }
+        cancelled.cancelExit()
+        XCTAssertEqual(reply, false)
+        XCTAssertEqual(cancelled.phase, .recoveryRequired)
+
+        hasProtectedOperation = false
+        reply = nil
+        XCTAssertEqual(cancelled.requestTermination { reply = $0 }, .terminateLater)
+        await waitUntil { cancelled.phase == .recoveryFailed }
+        XCTAssertNil(reply)
+    }
+
+    func testCancellationSuccessStillBlocksQuitWhenRecoveryFails() async {
+        var reply: Bool?
+        let coordinator = ApplicationTerminationCoordinator(
+            hasProtectedOperation: { true },
+            shutdownProtectedOperations: {},
+            cancelActiveHelper: { true },
+            recoverInterruptedOperation: { false }
+        )
+
+        XCTAssertEqual(coordinator.requestTermination { reply = $0 }, .terminateLater)
+        await waitUntil { coordinator.phase == .recoveryFailed }
+
+        XCTAssertNil(reply)
+    }
+
+    func testSuccessfulRetryAfterCancellingExitResumesProtectedOperations() async {
+        var recoverySucceeds = false
+        var didResume = false
+        var reply: Bool?
+        let coordinator = ApplicationTerminationCoordinator(
+            hasProtectedOperation: { true },
+            shutdownProtectedOperations: {},
+            cancelActiveHelper: { true },
+            recoverInterruptedOperation: { recoverySucceeds },
+            resumeProtectedOperations: { didResume = true }
+        )
+
+        XCTAssertEqual(coordinator.requestTermination { reply = $0 }, .terminateLater)
+        await waitUntil { coordinator.phase == .recoveryFailed }
+        coordinator.cancelExit()
+        XCTAssertEqual(reply, false)
+        XCTAssertEqual(coordinator.phase, .recoveryRequired)
+
+        recoverySucceeds = true
+        coordinator.retryRecovery()
+        await waitUntil { coordinator.phase == .idle }
+
+        XCTAssertTrue(didResume)
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 1,
+        condition: @escaping @MainActor () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline { await Task.yield() }
+        XCTAssertTrue(condition())
+    }
+}

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
@@ -253,7 +253,8 @@ final class BridgeClientExecutionTests: XCTestCase {
         let previewTask = Task { try await bridge.previewImportSource(locator: "anthropics/skills") }
         let previewPids = try await fixture.waitForCommand("preview-import-source")
 
-        XCTAssertTrue(await bridge.cancelActiveHelperForTermination())
+        let cancelled = await bridge.cancelActiveHelperForTermination()
+        XCTAssertTrue(cancelled)
         _ = try? await updateTask.value
         _ = try? await previewTask.value
 
@@ -265,7 +266,8 @@ final class BridgeClientExecutionTests: XCTestCase {
     func testTerminationLatchCancelsAProtectedOperationBeforeItsHelperLaunches() async {
         let bridge = await MainActor.run { BridgeClient() }
 
-        XCTAssertTrue(await bridge.cancelActiveHelperForTermination())
+        let cancelled = await bridge.cancelActiveHelperForTermination()
+        XCTAssertTrue(cancelled)
 
         do {
             _ = try await bridge.updateSources(["alpha"])
@@ -281,7 +283,8 @@ final class BridgeClientExecutionTests: XCTestCase {
         let fixture = try RecordingBridgeFixture.install()
         recordingFixture = fixture
         let bridge = await MainActor.run { BridgeClient() }
-        XCTAssertTrue(await bridge.cancelActiveHelperForTermination())
+        let cancelled = await bridge.cancelActiveHelperForTermination()
+        XCTAssertTrue(cancelled)
         bridge.enterRecoveryRequiredState()
 
         let preview = try await bridge.previewImportSource(locator: "anthropics/skills")

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
@@ -7,6 +7,7 @@ import XCTest
 final class BridgeClientExecutionTests: XCTestCase {
     private var fixture: SlowBridgeFixture?
     private var stubbornFixture: StubbornBridgeFixture?
+    private var stubbornProcessGroupFixture: StubbornProcessGroupBridgeFixture?
     private var recordingFixture: RecordingBridgeFixture?
     private var importDraftRetryFixture: ImportDraftRetryBridgeFixture?
     private var savedNodeOverride: String?
@@ -16,6 +17,8 @@ final class BridgeClientExecutionTests: XCTestCase {
         fixture = nil
         try stubbornFixture?.tearDown()
         stubbornFixture = nil
+        try stubbornProcessGroupFixture?.tearDown()
+        stubbornProcessGroupFixture = nil
         try recordingFixture?.tearDown()
         recordingFixture = nil
         try importDraftRetryFixture?.tearDown()
@@ -179,6 +182,37 @@ final class BridgeClientExecutionTests: XCTestCase {
         }
 
         try await waitForProcessToExit(pid: pid, timeoutNanoseconds: 1_000_000_000)
+    }
+
+    func testQuitCancellationKillsTheEntireHelperProcessGroupAfterGracePeriod() async throws {
+        let fixture = try StubbornProcessGroupBridgeFixture.install()
+        stubbornProcessGroupFixture = fixture
+        let bridge = await MainActor.run { BridgeClient(quitCancellationGraceMilliseconds: 50) }
+
+        let updateTask = Task { try await bridge.updateSources(["alpha"]) }
+        let pids = try await fixture.waitForPids()
+
+        let cancelled = await bridge.cancelActiveHelperForTermination()
+        XCTAssertTrue(cancelled)
+        _ = try? await updateTask.value
+
+        try await waitForProcessToExit(pid: pids.helper, timeoutNanoseconds: 1_000_000_000)
+        try await waitForProcessToExit(pid: pids.child, timeoutNanoseconds: 1_000_000_000)
+    }
+
+    func testTerminationLatchCancelsAProtectedOperationBeforeItsHelperLaunches() async {
+        let bridge = await MainActor.run { BridgeClient() }
+
+        XCTAssertTrue(await bridge.cancelActiveHelperForTermination())
+
+        do {
+            _ = try await bridge.updateSources(["alpha"])
+            XCTFail("Expected the queued protected operation to be cancelled before launch.")
+        } catch BridgeClientError.commandFailed(let message, _) {
+            XCTAssertTrue(message.contains("terminating"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     func testListFailsWithActionableNodeRequirementWhenNodeIsMissing() async throws {
@@ -695,6 +729,62 @@ final class BridgeClientExecutionTests: XCTestCase {
             return true
         }
         return errno == EPERM
+    }
+}
+
+private final class StubbornProcessGroupBridgeFixture {
+    private let rootURL: URL
+    private let pidsURL: URL
+    private let savedHelperOverride: String?
+
+    private init(rootURL: URL, pidsURL: URL, savedHelperOverride: String?) {
+        self.rootURL = rootURL
+        self.pidsURL = pidsURL
+        self.savedHelperOverride = savedHelperOverride
+    }
+
+    static func install() throws -> StubbornProcessGroupBridgeFixture {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("skillflow-desktop-bridge-process-group-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let helperURL = rootURL.appendingPathComponent("bridge-helper.js")
+        let pidsURL = rootURL.appendingPathComponent("pids.json")
+        let script = """
+        const fs = require("node:fs");
+        const { spawn } = require("node:child_process");
+        const child = spawn(process.execPath, ["-e", "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)"], { stdio: "ignore" });
+        fs.writeFileSync(\(String(reflecting: pidsURL.path)), JSON.stringify({ helper: process.pid, child: child.pid }));
+        process.on("SIGTERM", () => {});
+        process.stdin.resume();
+        setInterval(() => {}, 1000);
+        """
+        try script.write(to: helperURL, atomically: true, encoding: .utf8)
+        let saved = ProcessInfo.processInfo.environment["SKILL_FLOW_DESKTOP_HELPER_OVERRIDE"]
+        setenv("SKILL_FLOW_DESKTOP_HELPER_OVERRIDE", helperURL.path, 1)
+        return StubbornProcessGroupBridgeFixture(rootURL: rootURL, pidsURL: pidsURL, savedHelperOverride: saved)
+    }
+
+    func waitForPids() async throws -> (helper: Int32, child: Int32) {
+        let deadline = Date().addingTimeInterval(1)
+        while Date() < deadline {
+            if let data = try? Data(contentsOf: pidsURL),
+               let value = try? JSONSerialization.jsonObject(with: data) as? [String: Int],
+               let helper = value["helper"], let child = value["child"] {
+                return (Int32(helper), Int32(child))
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        throw XCTSkip("Timed out waiting for helper process group PIDs.")
+    }
+
+    func tearDown() throws {
+        if let savedHelperOverride { setenv("SKILL_FLOW_DESKTOP_HELPER_OVERRIDE", savedHelperOverride, 1) }
+        else { unsetenv("SKILL_FLOW_DESKTOP_HELPER_OVERRIDE") }
+        if let data = try? Data(contentsOf: pidsURL),
+           let value = try? JSONSerialization.jsonObject(with: data) as? [String: Int] {
+            for pid in value.values { if kill(Int32(pid), 0) == 0 { kill(Int32(pid), SIGKILL) } }
+        }
+        if FileManager.default.fileExists(atPath: rootURL.path) { try FileManager.default.removeItem(at: rootURL) }
     }
 }
 

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
@@ -227,6 +227,22 @@ final class BridgeClientExecutionTests: XCTestCase {
         try await waitForProcessToExit(pid: pids.child, timeoutNanoseconds: 1_000_000_000)
     }
 
+    func testQuitCancellationWaitsForDescendantsAfterHelperExits() async throws {
+        let fixture = try StubbornProcessGroupBridgeFixture.install(helperIgnoresTerm: false)
+        stubbornProcessGroupFixture = fixture
+        let bridge = await MainActor.run { BridgeClient(quitCancellationGraceMilliseconds: 50) }
+
+        let updateTask = Task { try await bridge.updateSources(["alpha"]) }
+        let pids = try await fixture.waitForPids()
+
+        let cancelled = await bridge.cancelActiveHelperForTermination()
+        XCTAssertTrue(cancelled)
+        _ = try? await updateTask.value
+
+        try await waitForProcessToExit(pid: pids.helper, timeoutNanoseconds: 1_000_000_000)
+        try await waitForProcessToExit(pid: pids.child, timeoutNanoseconds: 1_000_000_000)
+    }
+
     func testQuitCancellationStopsDurableAndDisposableHelpersWithoutLosingTheUpdate() async throws {
         let fixture = try ConcurrentHelpersBridgeFixture.install()
         concurrentHelpersFixture = fixture
@@ -814,18 +830,19 @@ private final class StubbornProcessGroupBridgeFixture {
         self.savedHelperOverride = savedHelperOverride
     }
 
-    static func install() throws -> StubbornProcessGroupBridgeFixture {
+    static func install(helperIgnoresTerm: Bool = true) throws -> StubbornProcessGroupBridgeFixture {
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("skillflow-desktop-bridge-process-group-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
         let helperURL = rootURL.appendingPathComponent("bridge-helper.js")
         let pidsURL = rootURL.appendingPathComponent("pids.json")
+        let helperTermHandler = helperIgnoresTerm ? "process.on(\"SIGTERM\", () => {});" : ""
         let script = """
         const fs = require("node:fs");
         const { spawn } = require("node:child_process");
         const child = spawn(process.execPath, ["-e", "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)"], { stdio: "ignore" });
         fs.writeFileSync(\(String(reflecting: pidsURL.path)), JSON.stringify({ helper: process.pid, child: child.pid }));
-        process.on("SIGTERM", () => {});
+        \(helperTermHandler)
         process.stdin.resume();
         setInterval(() => {}, 1000);
         """

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/BridgeClientExecutionTests.swift
@@ -8,6 +8,7 @@ final class BridgeClientExecutionTests: XCTestCase {
     private var fixture: SlowBridgeFixture?
     private var stubbornFixture: StubbornBridgeFixture?
     private var stubbornProcessGroupFixture: StubbornProcessGroupBridgeFixture?
+    private var concurrentHelpersFixture: ConcurrentHelpersBridgeFixture?
     private var recordingFixture: RecordingBridgeFixture?
     private var importDraftRetryFixture: ImportDraftRetryBridgeFixture?
     private var savedNodeOverride: String?
@@ -19,6 +20,8 @@ final class BridgeClientExecutionTests: XCTestCase {
         stubbornFixture = nil
         try stubbornProcessGroupFixture?.tearDown()
         stubbornProcessGroupFixture = nil
+        try concurrentHelpersFixture?.tearDown()
+        concurrentHelpersFixture = nil
         try recordingFixture?.tearDown()
         recordingFixture = nil
         try importDraftRetryFixture?.tearDown()
@@ -184,6 +187,30 @@ final class BridgeClientExecutionTests: XCTestCase {
         try await waitForProcessToExit(pid: pid, timeoutNanoseconds: 1_000_000_000)
     }
 
+    func testOrdinaryTimeoutDoesNotKillHelperDescendants() async throws {
+        let fixture = try StubbornProcessGroupBridgeFixture.install()
+        stubbornProcessGroupFixture = fixture
+        let bridge = await MainActor.run {
+            BridgeClient(commandTimeoutMilliseconds: 50, commandTimeoutGraceMilliseconds: 50)
+        }
+
+        let listTask = Task { try await bridge.list() }
+        let pids = try await fixture.waitForPids()
+
+        do {
+            _ = try await listTask.value
+            XCTFail("Expected list to time out before the helper exits.")
+        } catch {
+            XCTAssertEqual(error.localizedDescription, "Operation timed out after 50ms.")
+        }
+
+        try await waitForProcessToExit(pid: pids.helper, timeoutNanoseconds: 1_000_000_000)
+        XCTAssertTrue(
+            isProcessRunning(pid: pids.child),
+            "Ordinary timeout should preserve the upstream scope and leave helper descendants alone."
+        )
+    }
+
     func testQuitCancellationKillsTheEntireHelperProcessGroupAfterGracePeriod() async throws {
         let fixture = try StubbornProcessGroupBridgeFixture.install()
         stubbornProcessGroupFixture = fixture
@@ -200,6 +227,25 @@ final class BridgeClientExecutionTests: XCTestCase {
         try await waitForProcessToExit(pid: pids.child, timeoutNanoseconds: 1_000_000_000)
     }
 
+    func testQuitCancellationStopsDurableAndDisposableHelpersWithoutLosingTheUpdate() async throws {
+        let fixture = try ConcurrentHelpersBridgeFixture.install()
+        concurrentHelpersFixture = fixture
+        let bridge = await MainActor.run { BridgeClient(quitCancellationGraceMilliseconds: 50) }
+
+        let updateTask = Task { try await bridge.updateSources(["alpha"]) }
+        let updatePids = try await fixture.waitForCommand("update")
+        let previewTask = Task { try await bridge.previewImportSource(locator: "anthropics/skills") }
+        let previewPids = try await fixture.waitForCommand("preview-import-source")
+
+        XCTAssertTrue(await bridge.cancelActiveHelperForTermination())
+        _ = try? await updateTask.value
+        _ = try? await previewTask.value
+
+        for pid in [updatePids.helper, updatePids.child, previewPids.helper, previewPids.child] {
+            try await waitForProcessToExit(pid: pid, timeoutNanoseconds: 1_000_000_000)
+        }
+    }
+
     func testTerminationLatchCancelsAProtectedOperationBeforeItsHelperLaunches() async {
         let bridge = await MainActor.run { BridgeClient() }
 
@@ -212,6 +258,29 @@ final class BridgeClientExecutionTests: XCTestCase {
             XCTAssertTrue(message.contains("terminating"))
         } catch {
             XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testRecoveryRequiredAllowsPreviewButRejectsPreparationAndDurableMutation() async throws {
+        let fixture = try RecordingBridgeFixture.install()
+        recordingFixture = fixture
+        let bridge = await MainActor.run { BridgeClient() }
+        XCTAssertTrue(await bridge.cancelActiveHelperForTermination())
+        bridge.enterRecoveryRequiredState()
+
+        let preview = try await bridge.previewImportSource(locator: "anthropics/skills")
+        XCTAssertTrue(preview.ok)
+
+        for operation in [
+            { try await bridge.prepareImportSource(locator: "anthropics/skills") },
+            { try await bridge.updateSources(["alpha"]) },
+        ] {
+            do {
+                _ = try await operation()
+                XCTFail("Expected Recovery Required to reject preparation and durable mutation.")
+            } catch BridgeClientError.commandFailed(let message, _) {
+                XCTAssertTrue(message.contains("terminating"))
+            }
         }
     }
 
@@ -552,7 +621,7 @@ final class BridgeClientExecutionTests: XCTestCase {
         XCTAssertNil(draft["selectedSkillIds"])
     }
 
-    func testImportSourceAlwaysSendsSelectedSkillsPayload() async throws {
+    func testDesktopImportSourcePreparesThenCommitsSelectedSkillsPayload() async throws {
         let fixture = try RecordingBridgeFixture.install()
         recordingFixture = fixture
 
@@ -567,8 +636,9 @@ final class BridgeClientExecutionTests: XCTestCase {
         )
 
         let payload = try fixture.lastPayload()
-        XCTAssertEqual(try fixture.lastCommand(), "import-source")
-        XCTAssertEqual(payload["locator"] as? String, "anthropics/skills")
+        XCTAssertEqual(try fixture.loggedCommands(), ["prepare-import-source", "commit-import-source"])
+        XCTAssertEqual(try fixture.lastCommand(), "commit-import-source")
+        XCTAssertEqual(payload["preparationId"] as? String, "prep-desktop")
         let draft = try XCTUnwrap(payload["draft"] as? [String: Any])
         XCTAssertEqual(draft["skillSelectionMode"] as? String, "selected")
         let selectedSkills = try XCTUnwrap(draft["selectedSkills"] as? [[String: Any]])
@@ -578,7 +648,7 @@ final class BridgeClientExecutionTests: XCTestCase {
         XCTAssertNil(draft["selectedSkillIds"])
     }
 
-    func testImportSourceCanSendAllSkillSelectionMode() async throws {
+    func testDesktopImportSourceCanCommitAllSkillSelectionMode() async throws {
         let fixture = try RecordingBridgeFixture.install()
         recordingFixture = fixture
 
@@ -592,7 +662,8 @@ final class BridgeClientExecutionTests: XCTestCase {
         )
 
         let payload = try fixture.lastPayload()
-        XCTAssertEqual(try fixture.lastCommand(), "import-source")
+        XCTAssertEqual(try fixture.loggedCommands(), ["prepare-import-source", "commit-import-source"])
+        XCTAssertEqual(try fixture.lastCommand(), "commit-import-source")
         let draft = try XCTUnwrap(payload["draft"] as? [String: Any])
         XCTAssertEqual(draft["skillSelectionMode"] as? String, "all")
         XCTAssertEqual((draft["selectedSkills"] as? [[String: Any]])?.count, 0)
@@ -783,6 +854,91 @@ private final class StubbornProcessGroupBridgeFixture {
         if let data = try? Data(contentsOf: pidsURL),
            let value = try? JSONSerialization.jsonObject(with: data) as? [String: Int] {
             for pid in value.values { if kill(Int32(pid), 0) == 0 { kill(Int32(pid), SIGKILL) } }
+        }
+        if FileManager.default.fileExists(atPath: rootURL.path) { try FileManager.default.removeItem(at: rootURL) }
+    }
+}
+
+private final class ConcurrentHelpersBridgeFixture {
+    private let rootURL: URL
+    private let recordsURL: URL
+    private let savedHelperOverride: String?
+
+    private init(rootURL: URL, recordsURL: URL, savedHelperOverride: String?) {
+        self.rootURL = rootURL
+        self.recordsURL = recordsURL
+        self.savedHelperOverride = savedHelperOverride
+    }
+
+    static func install() throws -> ConcurrentHelpersBridgeFixture {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("skillflow-desktop-concurrent-helpers-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let helperURL = rootURL.appendingPathComponent("bridge-helper.js")
+        let recordsURL = rootURL.appendingPathComponent("helpers.jsonl")
+        let script = """
+        const fs = require("node:fs");
+        const { spawn } = require("node:child_process");
+        let input = "";
+        process.stdin.setEncoding("utf8");
+        process.stdin.on("data", chunk => { input += chunk; });
+        process.stdin.on("end", () => {
+          const request = JSON.parse(input || "{}");
+          const child = spawn(process.execPath, ["-e", "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)"], { stdio: "ignore" });
+          fs.appendFileSync(
+            \(String(reflecting: recordsURL.path)),
+            JSON.stringify({ command: request.command, helper: process.pid, child: child.pid }) + "\\n"
+          );
+        });
+        process.on("SIGTERM", () => {});
+        process.stdin.resume();
+        setInterval(() => {}, 1000);
+        """
+        try script.write(to: helperURL, atomically: true, encoding: .utf8)
+        let saved = ProcessInfo.processInfo.environment["SKILL_FLOW_DESKTOP_HELPER_OVERRIDE"]
+        setenv("SKILL_FLOW_DESKTOP_HELPER_OVERRIDE", helperURL.path, 1)
+        return ConcurrentHelpersBridgeFixture(
+            rootURL: rootURL,
+            recordsURL: recordsURL,
+            savedHelperOverride: saved
+        )
+    }
+
+    func waitForCommand(_ command: String) async throws -> (helper: Int32, child: Int32) {
+        let deadline = Date().addingTimeInterval(1)
+        while Date() < deadline {
+            if let contents = try? String(contentsOf: recordsURL, encoding: .utf8) {
+                for line in contents.split(separator: "\n") {
+                    guard
+                        let data = line.data(using: .utf8),
+                        let value = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                        value["command"] as? String == command,
+                        let helper = value["helper"] as? Int,
+                        let child = value["child"] as? Int
+                    else { continue }
+                    return (Int32(helper), Int32(child))
+                }
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        throw XCTSkip("Timed out waiting for helper command '\(command)'.")
+    }
+
+    func tearDown() throws {
+        if let savedHelperOverride { setenv("SKILL_FLOW_DESKTOP_HELPER_OVERRIDE", savedHelperOverride, 1) }
+        else { unsetenv("SKILL_FLOW_DESKTOP_HELPER_OVERRIDE") }
+        if let contents = try? String(contentsOf: recordsURL, encoding: .utf8) {
+            for line in contents.split(separator: "\n") {
+                guard
+                    let data = line.data(using: .utf8),
+                    let value = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                else { continue }
+                for key in ["helper", "child"] {
+                    if let pid = value[key] as? Int, kill(Int32(pid), 0) == 0 {
+                        kill(Int32(pid), SIGKILL)
+                    }
+                }
+            }
         }
         if FileManager.default.fileExists(atPath: rootURL.path) { try FileManager.default.removeItem(at: rootURL) }
     }
@@ -995,7 +1151,9 @@ private final class RecordingBridgeFixture {
           fs.appendFileSync(\(String(reflecting: logPath)), JSON.stringify(request) + "\\n", "utf8");
           const data = request.command === "bootstrap"
             ? { command: request.command ?? "list", capabilities: { importDraftV2: true } }
-            : { command: request.command ?? "list" };
+            : request.command === "prepare-import-source"
+              ? { command: request.command, status: "ready", preparationId: "prep-desktop" }
+              : { command: request.command ?? "list" };
           const response = {
             protocolVersion: "1.0",
             requestId: request.requestId ?? null,

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/GroupOperationQueueTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/GroupOperationQueueTests.swift
@@ -78,4 +78,25 @@ final class GroupOperationQueueTests: XCTestCase {
         XCTAssertEqual(queue.enqueueBulkUpdate(sourceIds: ["a", "b"]), .enqueued)
         XCTAssertEqual(queue.enqueueBulkUpdate(sourceIds: ["c"]), .alreadyPresent)
     }
+
+    func testShutdownDiscardsQueuedWorkAndFreezesTheQueueUntilRecoveryResumesIt() {
+        let queue = GroupOperationQueue()
+
+        XCTAssertEqual(queue.enqueueUpdate(sourceId: "running"), .enqueued)
+        XCTAssertEqual(queue.enqueueImport(groupId: "queued"), .enqueued)
+        XCTAssertEqual(queue.startNext(), .update(sourceId: "running"))
+
+        XCTAssertEqual(queue.shutdown(), .update(sourceId: "running"))
+        XCTAssertFalse(queue.hasQueuedWork)
+        XCTAssertEqual(queue.updatePhase(for: "running"), .running)
+        XCTAssertNil(queue.importPhase(for: "queued"))
+
+        XCTAssertEqual(queue.enqueueUpdate(sourceId: "later"), .shutDown)
+        XCTAssertEqual(queue.enqueueImport(groupId: "later"), .shutDown)
+        XCTAssertEqual(queue.enqueueBulkUpdate(sourceIds: ["later"]), .shutDown)
+
+        queue.resumeAfterRecovery()
+        XCTAssertNil(queue.updatePhase(for: "running"))
+        XCTAssertEqual(queue.enqueueUpdate(sourceId: "later"), .enqueued)
+    }
 }

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/WorkflowCoverageTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/WorkflowCoverageTests.swift
@@ -494,11 +494,14 @@ final class WorkflowCoverageTests: XCTestCase {
         XCTAssertEqual(model.toast?.message, "Imported source.")
 
         let importRequests = fixture.loggedRequests().filter { $0.command == "import-source" }
-        XCTAssertEqual(importRequests.count, 1)
+        XCTAssertEqual(importRequests.count, 0)
+        let prepareRequests = fixture.loggedRequests().filter { $0.command == "prepare-import-source" }
+        XCTAssertEqual(prepareRequests.count, 1)
         let commitRequests = fixture.loggedRequests().filter { $0.command == "commit-import-source" }
-        XCTAssertEqual(commitRequests.count, 0)
-        XCTAssertEqual(importRequests.first?.payload?["locator"]?.value as? String, "anthropics/skills")
-        let draft = importRequests.first?.payload?["draft"]?.value as? [String: Any]
+        XCTAssertEqual(commitRequests.count, 1)
+        XCTAssertEqual(prepareRequests.first?.payload?["locator"]?.value as? String, "anthropics/skills")
+        XCTAssertEqual(commitRequests.first?.payload?["preparationId"]?.value as? String, "prep-anthropics-skills")
+        let draft = commitRequests.first?.payload?["draft"]?.value as? [String: Any]
         XCTAssertEqual(draft?["skillSelectionMode"] as? String, "selected")
         let selectedSkills = draft?["selectedSkills"] as? [[String: Any]]
         XCTAssertEqual(selectedSkills?.first?["uiId"] as? String, "research")
@@ -1135,6 +1138,24 @@ private struct TestFixture {
       return `prep-${normalizeRepo(value).replace(/[^a-z0-9]+/g, '-')}`;
     }
 
+    function importFailureForGroup(state, group) {
+      if (!state.importFailures || !group) {
+        return null;
+      }
+      const candidates = [group.canonicalRepo, group.locator].concat(group.aliases || []);
+      for (const candidate of candidates) {
+        const directFailure = state.importFailures[candidate];
+        if (directFailure) {
+          return directFailure;
+        }
+        const normalizedFailure = state.importFailures[normalizeRepo(candidate)];
+        if (normalizedFailure) {
+          return normalizedFailure;
+        }
+      }
+      return null;
+    }
+
     function installedCanonicalRepos(state) {
       return new Set(
         Object.values(state.sources || {})
@@ -1488,15 +1509,6 @@ private struct TestFixture {
 
       if (request.command === 'import-source') {
         const locator = String((request.payload && request.payload.locator) || '');
-        const failureReason = state.importFailures && state.importFailures[locator];
-        if (failureReason) {
-          process.stdout.write(JSON.stringify(responseFor(request, true, {
-            status: 'failed',
-            reasonCode: failureReason
-          }, [], [])));
-          return;
-        }
-
         const normalizedLocator = normalizeRepo(locator);
         const group = (state.importGroups || []).find((candidate) => {
           const aliases = [candidate.canonicalRepo, candidate.locator].concat(candidate.aliases || []).map(normalizeRepo);
@@ -1507,6 +1519,15 @@ private struct TestFixture {
           process.stdout.write(JSON.stringify(responseFor(request, true, {
             status: 'failed',
             reasonCode: 'provider_data_unavailable'
+          }, [], [])));
+          return;
+        }
+
+        const failureReason = importFailureForGroup(state, group);
+        if (failureReason) {
+          process.stdout.write(JSON.stringify(responseFor(request, true, {
+            status: 'failed',
+            reasonCode: failureReason
           }, [], [])));
           return;
         }
@@ -1547,6 +1568,15 @@ private struct TestFixture {
           process.stdout.write(JSON.stringify(responseFor(request, true, {
             status: 'failed',
             reasonCode: 'provider_data_unavailable'
+          }, [], [])));
+          return;
+        }
+
+        const failureReason = importFailureForGroup(state, group);
+        if (failureReason) {
+          process.stdout.write(JSON.stringify(responseFor(request, true, {
+            status: 'failed',
+            reasonCode: failureReason
           }, [], [])));
           return;
         }

--- a/docs/adr/0002-desktop-group-operation-queue.md
+++ b/docs/adr/0002-desktop-group-operation-queue.md
@@ -14,4 +14,6 @@ Desktop users need to click Update/Import on many skill groups without waiting f
 - `MutationCoordinator` must wait/queue rather than throw on overlap.
 - Import no longer disables sibling import buttons; it enqueues.
 - Update All is one Bulk Update job that absorbs matching single-group Updates.
-- CLI/TUI unchanged; no cancel, no task panel, no end-of-queue summary toast in v1.
+- CLI/TUI unchanged; no general Cancel action, no task panel, and no end-of-queue
+  summary toast in v1. Application-termination cancellation is defined by
+  [ADR 0003](0003-desktop-quit-operation-recovery.md).

--- a/docs/adr/0003-desktop-quit-operation-recovery.md
+++ b/docs/adr/0003-desktop-quit-operation-recovery.md
@@ -1,0 +1,63 @@
+# Desktop Quit Operation Recovery
+
+## Context
+
+The desktop Group Operation Queue is session-scoped. Queued Update and Import
+operations are intentionally not durable, but a running operation can cross
+several filesystem commits: managed checkout replacement, authority state
+writes, and target projection reconciliation. Terminating the desktop helper
+between those commits can leave a managed group inconsistent on the next
+launch.
+
+ADR 0002 deliberately omitted cancellation from the first queue version. This
+ADR adds a narrower capability: cancellation only while the macOS application
+is terminating. It does not add a task panel, resumable work, or a general
+Cancel action.
+
+## Decision
+
+- Command-Q and the application Quit menu freeze the Group Operation Queue,
+  discard Queued operations, and cancel the single Running operation. Closing
+  the main window does not cancel work.
+- A completed operation remains committed. During Bulk Update, groups that
+  reached their per-group commit point remain committed; only the current
+  incomplete group is recovered.
+- A group reaches its commit point only after its managed checkout, authority
+  state, and owned target projections are mutually consistent.
+- Import discovery and preparation remain disposable cache work. Final import
+  commit and managed update use durable operation recovery.
+- The helper receives cooperative termination first. The desktop waits five
+  seconds, then terminates the helper process group if it is still running.
+- A recovery journal is written before protected mutation. It records recovery
+  evidence, not work to resume. No Queued or Running operation is replayed.
+- Bootstrap recovers an unfinished journal before checkout pruning or new
+  mutations. Normal quit and process-crash recovery are supported; sudden
+  power loss remains best effort and does not carry an fsync-level guarantee.
+- Recovery restores authority and managed checkout state, then restores or
+  reconciles only Skill Flow-owned target projections. It never adopts,
+  overwrites, or removes externally owned source paths.
+- If an owned target no longer matches the fingerprint written by the running
+  operation, recovery reports a conflict instead of overwriting the external
+  change.
+- Successful recovery completes the pending Quit request. Failed recovery
+  blocks normal termination and offers Retry Recovery or Cancel Quit; protected
+  mutations remain disabled until recovery succeeds. If Quit was cancelled,
+  successful recovery reopens a fresh empty session queue without replaying
+  discarded or interrupted work.
+- Cancellation uses process signals and bootstrap recovery. The public bridge
+  protocol gains no cancel or recover command.
+
+## Consequences
+
+- The queue stays session-scoped and single-flight, preserving ADR 0002's FIFO
+  and serial mutation decisions.
+- `no cancel` in ADR 0002 is superseded only for application termination.
+- Recovery state is an internal durable implementation detail, separate from
+  Shared Skill State authority files, migration markers, and Desktop Workspace
+  Memory.
+- Managed update and final import require a per-group transaction seam that
+  keeps checkout backups until authority and deployment commit together.
+- The previous timeout guidance that allowed the operating system to clean up
+  an unresponsive helper is superseded for protected desktop operations: the
+  complete helper process group is terminated after the grace period.
+- CLI and TUI behavior and external-source lifecycle rules remain unchanged.

--- a/docs/adr/0003-desktop-quit-operation-recovery.md
+++ b/docs/adr/0003-desktop-quit-operation-recovery.md
@@ -24,17 +24,19 @@ Cancel action.
   incomplete group is recovered.
 - A group reaches its commit point only after its managed checkout, authority
   state, and owned target projections are mutually consistent.
-- Import discovery and preparation remain disposable cache work. Final import
-  commit and managed update use durable operation recovery.
-- The helper receives cooperative termination first. The desktop waits five
-  seconds, then terminates the helper process group if it is still running.
+- Import search, local scan, preview, and preparation remain disposable work.
+  Final import commit and managed update use durable operation recovery.
+- Quit first stops all active durable and disposable helper process groups. It
+  waits five seconds after cooperative termination, then kills survivors.
+  Ordinary command timeout retains the upstream helper-only behavior.
 - A recovery journal is written before protected mutation. It records recovery
   evidence, not work to resume. No Queued or Running operation is replayed.
 - Bootstrap recovers an unfinished journal before checkout pruning or new
   mutations. Normal quit and process-crash recovery are supported; sudden
   power loss remains best effort and does not carry an fsync-level guarantee.
-- Recovery restores authority and managed checkout state, then restores or
-  reconciles only Skill Flow-owned target projections. It never adopts,
+- Recovery validates every journal path and its semantic ownership before path
+  I/O, then restores managed checkout, authority state, and only Skill
+  Flow-owned target projections in that order. It never adopts,
   overwrites, or removes externally owned source paths.
 - If an owned target no longer matches the fingerprint written by the running
   operation, recovery reports a conflict instead of overwriting the external
@@ -46,6 +48,14 @@ Cancel action.
   discarded or interrupted work.
 - Cancellation uses process signals and bootstrap recovery. The public bridge
   protocol gains no cancel or recover command.
+- Bulk Update validates the complete selected source list before starting its
+  existing per-group transactions.
+- Recovery Required permits import discovery queries but blocks preparation,
+  final Import, and Update. Disposable-only cleanup failure does not block Quit
+  and is retried during bootstrap.
+- Migration is recovery-aware under the schema-independent mutation lock:
+  current V2 recovers first, V1 plus an active journal is rejected, and dry-run
+  remains read-only.
 
 ## Consequences
 
@@ -57,7 +67,6 @@ Cancel action.
   Memory.
 - Managed update and final import require a per-group transaction seam that
   keeps checkout backups until authority and deployment commit together.
-- The previous timeout guidance that allowed the operating system to clean up
-  an unresponsive helper is superseded for protected desktop operations: the
-  complete helper process group is terminated after the grace period.
+- Process-group termination applies only to application Quit. Ordinary timeout
+  continues to terminate only the helper process.
 - CLI and TUI behavior and external-source lifecycle rules remain unchanged.

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -74,10 +74,15 @@ When adding, removing, or renaming a bridge command:
 | `manifest.json` | User intent: sources, selected skills, enabled targets, display state. |
 | `lock.json` | Resolved state: inventory snapshots, projections, source metadata. |
 | `preferences.json` | Local preferences, target overrides, desktop-facing settings. |
+| `recovery/active.json` | Internal compensation journal for one interrupted managed Update or final Import; not authority and never resumed as queued work. |
 
 State compatibility is implemented in `packages/storage` and domain types live in `packages/domain`.
 
 State shape changes are external changes. Add storage/domain tests and migration or normalizer coverage.
+
+The recovery journal has its own internal schema validation and must be
+recovered before bootstrap prunes missing checkouts. Invalid journals block
+recovery rather than supplying filesystem paths to cleanup logic.
 
 External sources use `ownership: "external"` in manifest/lock state. Their
 paths are observation-only: they cannot receive target bindings, managed

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -64,7 +64,7 @@ When adding, removing, or renaming a bridge command:
 2. Update the golden fixture in `packages/shared-types/src/fixtures/bridge-command-catalog.json`.
 3. Update the CLI handler table in `apps/cli/src/bridge-command.ts`.
 4. Update `BridgeCommand` in `apps/desktop-mac/Sources/DesktopApp/Runtime/Models/BridgeProtocol.swift`.
-5. Update `BridgeCommand.usesImportTimeout` when the command should use the import timeout.
+5. Update `BridgeCommand.usesExtendedNetworkTimeout` when the command should use the extended desktop helper timeout.
 6. Run the TypeScript protocol tests, CLI bridge tests, and Swift bridge catalog tests.
 
 ## State Files

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -80,9 +80,15 @@ State compatibility is implemented in `packages/storage` and domain types live i
 
 State shape changes are external changes. Add storage/domain tests and migration or normalizer coverage.
 
-The recovery journal has its own internal schema validation and must be
-recovered before bootstrap prunes missing checkouts. Invalid journals block
-recovery rather than supplying filesystem paths to cleanup logic.
+The recovery journal has structural and semantic validation and must be
+recovered before bootstrap prunes missing checkouts. It records source kind,
+checkout/source ownership, and target IDs. Recovery re-detects current target
+roots and validates the entire authority snapshot and every path before any
+fingerprint, cleanup, or restore. Invalid structure returns
+`RECOVERY_JOURNAL_INVALID`; invalid path ownership returns
+`RECOVERY_PATH_OWNERSHIP_INVALID`. Neither supplies filesystem paths to cleanup
+logic. Migration under the schema-independent mutation lock recovers current
+V2 state first, rejects V1 plus an active journal, and leaves dry-run read-only.
 
 External sources use `ownership: "external"` in manifest/lock state. Their
 paths are observation-only: they cannot receive target bindings, managed

--- a/docs/superpowers/specs/2026-06-03-import-timeout-and-feedback-design.md
+++ b/docs/superpowers/specs/2026-06-03-import-timeout-and-feedback-design.md
@@ -53,7 +53,10 @@ Implementation detail:
 
 - Race subprocess termination against a sleep task.
 - On timeout, call `process.terminate()`.
-- If the process does not terminate shortly after SIGTERM, still return timeout to the UI and let the OS clean up.
+- If the process does not terminate shortly after SIGTERM, still return timeout
+  to the UI. For a protected desktop Group Operation during application Quit,
+  the later Desktop Quit Operation Recovery design supersedes OS cleanup: wait
+  five seconds, then terminate the helper process group.
 - Keep existing stdout and stderr parsing unchanged for non-timeout exits.
 
 ### Network Request Timeout

--- a/docs/superpowers/specs/2026-06-03-import-timeout-and-feedback-design.md
+++ b/docs/superpowers/specs/2026-06-03-import-timeout-and-feedback-design.md
@@ -53,10 +53,11 @@ Implementation detail:
 
 - Race subprocess termination against a sleep task.
 - On timeout, call `process.terminate()`.
-- If the process does not terminate shortly after SIGTERM, still return timeout
-  to the UI. For a protected desktop Group Operation during application Quit,
-  the later Desktop Quit Operation Recovery design supersedes OS cleanup: wait
-  five seconds, then terminate the helper process group.
+- If the process does not terminate shortly after SIGTERM, force-kill only the
+  helper and return timeout to the UI; ordinary timeout does not expand to its
+  descendants. During application Quit, the later Desktop Quit Operation
+  Recovery design separately stops every cancellable helper process group,
+  waits five seconds, then kills surviving groups.
 - Keep existing stdout and stderr parsing unchanged for non-timeout exits.
 
 ### Network Request Timeout

--- a/docs/superpowers/specs/2026-08-18-git-source-update-boundaries-design.md
+++ b/docs/superpowers/specs/2026-08-18-git-source-update-boundaries-design.md
@@ -65,7 +65,10 @@ budget based on the distinct selected source count:
 - update all: 15 minutes.
 
 Tests may inject shorter budgets. Timeout termination and output handling stay
-the same as other bridge commands.
+the same as other bridge commands. Application Quit is a separate lifecycle:
+the Desktop Quit Operation Recovery design freezes the queue, requests
+cooperative cancellation, and terminates the helper process group after its
+five-second grace period without changing these update budgets.
 
 ## Acceptance tests
 

--- a/docs/superpowers/specs/2026-08-22-desktop-quit-operation-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-22-desktop-quit-operation-recovery-design.md
@@ -1,0 +1,158 @@
+# Desktop Quit Operation Recovery Design
+
+## Goal
+
+Make quitting the macOS application safe while a managed group Update, Bulk
+Update, or final Import is running. A later launch must either observe the last
+completed group state or finish recovering the one incomplete group before new
+protected mutations begin.
+
+## Scope
+
+Protected operations:
+
+- managed single-group Update;
+- managed Bulk Update, with a commit point per group;
+- final Import commit.
+
+Import search, preview, and preparation may be cancelled and their interrupted
+temporary data cleaned without a full transaction. Pin, rename, apply,
+uninstall, collection, settings, migration, doctor, and external-source
+operations retain their existing behavior.
+
+## Interfaces And Seams
+
+### Desktop queue shutdown
+
+The Group Operation Queue remains a session FIFO with one running slot. Its
+shutdown interface atomically:
+
+1. refuses new operations;
+2. removes Queued operations;
+3. exposes the Running operation until cancellation and recovery finish;
+4. prevents `drain()` from scheduling more work.
+
+Queued and Running work is never resumed. If Quit was cancelled after recovery
+failed, protected operations remain disabled. A later successful in-app
+recovery may reopen a fresh empty session queue.
+
+### Operation recovery module
+
+One deep module owns the durable journal and recovery state machine. Callers
+can begin a protected group mutation, advance durable stages, commit it, or
+recover the unfinished operation. Callers do not read or edit journal files.
+
+The journal is stored separately from authority files and
+`.skillflow-migration.json`. It contains an operation identifier, operation
+kind, source identifier, phase, managed checkout recovery paths, the authority
+snapshot needed for compensation, and owned-target fingerprints and recovery
+paths.
+
+Journal writes use the repository's normal atomic file replacement guarantees.
+They do not promise file-and-directory fsync durability across sudden power
+loss.
+
+### Helper cancellation
+
+BridgeClient owns a registry of the active helper for protected operations.
+Application termination sends cooperative termination and waits up to five
+seconds. If the helper remains alive, the whole process group is killed so Git
+or archive grandchildren do not continue after the desktop exits.
+
+The registry also latches termination before a protected helper starts. If a
+short non-protected mutation currently owns the Serial Mutation Channel, it is
+allowed to finish normally; the queued Update or Import is then rejected before
+launch instead of killing the unrelated helper.
+
+There is no public bridge command change. The Node bridge handles termination
+inside the running helper; bootstrap invokes recovery before normal workspace
+cleanup.
+
+### Application termination
+
+An AppKit termination coordinator returns `terminateLater` only when a
+protected Group Operation is active. It freezes the queue, presents a stopping
+and recovery state, and replies to the pending termination request after
+recovery succeeds. Failure keeps the application open with Retry Recovery and
+Cancel Quit actions. Cancel Quit leaves a visible Recovery Required state and
+keeps Update and Import disabled; a later Quit cannot bypass the unfinished
+journal.
+
+## Per-group commit contract
+
+A managed group is committed only when all of the following describe the same
+version:
+
+1. canonical managed checkout;
+2. manifest and lock authority state;
+3. Skill Flow-owned target projections.
+
+Bulk Update remains one bridge command and one desktop Group Operation. The
+runtime advances one source through the complete per-group transaction before
+starting the next source. On cancellation, earlier committed sources remain;
+the current source is recovered.
+
+Final Import uses the same commit contract. If no source existed before the
+operation, recovery removes the incomplete managed source registration and its
+owned projections while restoring any managed path moved aside by the import.
+
+## Ownership and conflicts
+
+- Managed checkout validation from the Git source update boundary remains
+  mandatory before staging, replacement, or recovery.
+- `ownership: "external"` sources never enter this transaction path.
+- Target directories are projections, not authority. Recovery evidence covers
+  only paths the planner classified as Skill Flow-owned.
+- Before restoring an owned target, recovery compares its current fingerprint
+  with the value produced by the interrupted operation. A mismatch is a
+  recovery conflict and is never overwritten automatically.
+
+## Bootstrap ordering
+
+Bootstrap performs these steps in order:
+
+1. acquire the mutation lock, reclaiming a dead helper's lock by the existing
+   PID rules;
+2. inspect and recover any unfinished operation journal;
+3. stop with a structured recovery conflict if compensation cannot complete;
+4. only then run missing-checkout pruning and ordinary bootstrap reconciliation.
+
+Successful recovery deletes operation backups and the journal. It never
+re-enqueues or resumes the interrupted operation. When the user previously
+cancelled Quit, success also clears the desktop cancellation latch and opens a
+fresh empty queue so new work can be requested normally.
+
+## Compatibility updates
+
+- ADR 0002's v1 `no cancel` decision is superseded only for application Quit.
+- The import timeout design's OS-cleanup fallback is superseded by process-group
+  termination for protected operations.
+- Git update time budgets remain unchanged; application Quit has its own
+  five-second cooperative cancellation grace period.
+- Bridge protocol 1.0 command names and payloads remain unchanged.
+
+## Acceptance tests
+
+1. Queue shutdown drops Queued operations and cannot restart draining until a
+   recovery succeeds after the user has cancelled Quit; reopening starts with
+   an empty queue and never replays the interrupted work.
+2. Quit with no protected operation terminates immediately.
+3. Quit with a Running operation enters delayed termination and displays
+   stopping/recovery feedback.
+4. A cooperative helper exits during the grace period without forced kill.
+5. An unresponsive helper and its descendant process are terminated after the
+   grace period.
+6. Cancellation before and after every checkout replacement stage restores the
+   previous managed group.
+7. Cancellation during authority promotion or target deployment restores the
+   previous managed group.
+8. Bulk Update preserves previously committed groups and restores only the
+   current incomplete group.
+9. Final Import recovery removes an incomplete new group and restores owned
+   target paths.
+10. Import preparation cancellation cleans interrupted preparation while
+    preserving reusable Ready preparation records.
+11. A target fingerprint mismatch blocks recovery without overwriting the path.
+12. Bootstrap recovers an unfinished journal before missing-checkout pruning.
+13. Recovery success clears backups and journal; failure keeps protected
+    mutations disabled and supports retry.

--- a/docs/superpowers/specs/2026-08-22-desktop-quit-operation-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-22-desktop-quit-operation-recovery-design.md
@@ -2,157 +2,160 @@
 
 ## Goal
 
-Make quitting the macOS application safe while a managed group Update, Bulk
-Update, or final Import is running. A later launch must either observe the last
-completed group state or finish recovering the one incomplete group before new
-protected mutations begin.
+Make macOS application Quit safe while managed Update or final Import work is
+running. A later launch observes the last committed group state or completes
+compensation for the one incomplete group before another protected mutation.
 
-## Scope
+## Operation classes
 
-Protected operations:
+- **Durable mutations:** managed single/Bulk Update and final Import commit.
+  These use the recovery journal.
+- **Preparation:** import checkout preparation. It is disposable and does not
+  use the durable journal.
+- **Disposable queries:** import search, local scan, and preview. Their helper
+  work may be stopped and their interrupted temporary data cleaned.
+- Other commands retain their existing behavior and serial-mutation rules.
 
-- managed single-group Update;
-- managed Bulk Update, with a commit point per group;
-- final Import commit.
+The public CLI/TUI command surface is unchanged. The desktop always performs
+final Import as `prepare-import-source` followed by `commit-import-source` so
+the durable boundary is explicit. The existing public `import-source` direct
+fallback remains available to non-desktop callers.
 
-Import search, preview, and preparation may be cancelled and their interrupted
-temporary data cleaned without a full transaction. Pin, rename, apply,
-uninstall, collection, settings, migration, doctor, and external-source
-operations retain their existing behavior.
+## Desktop queue and helper shutdown
 
-## Interfaces And Seams
+Quit is Command-Q or the application Quit menu, not main-window closure. It
+atomically refuses new Group Operations, discards Queued work, and retains the
+Running identity until cancellation and recovery finish. Work is never resumed
+or replayed.
 
-### Desktop queue shutdown
+`BridgeClient` tracks all active helpers, not only one process. Each helper is
+registered with its operation class before launch can cross the termination
+latch. On Quit, all active durable, preparation, and disposable-query helpers
+are stopped before recovery begins. Cooperative shutdown sends TERM to each
+helper process group; after five seconds, any surviving group is killed.
 
-The Group Operation Queue remains a session FIFO with one running slot. Its
-shutdown interface atomically:
+This process-group behavior is Quit-only. An ordinary command timeout preserves
+the upstream helper-only contract: terminate the helper, wait its existing
+grace period, then force-kill that helper if needed. Ordinary timeout does not
+newly kill descendant processes.
 
-1. refuses new operations;
-2. removes Queued operations;
-3. exposes the Running operation until cancellation and recovery finish;
-4. prevents `drain()` from scheduling more work.
+Quit is delayed whenever protected queue work or any cancellable helper is
+active. Disposable-only cleanup is best effort: cleanup failure does not block
+Quit and bootstrap retries it next launch. Durable recovery failure keeps the
+application open. If the user cancels Quit, the app enters **Recovery
+Required**: search, local scan, and preview remain available; preparation,
+final Import, and Update are rejected until recovery succeeds.
 
-Queued and Running work is never resumed. If Quit was cancelled after recovery
-failed, protected operations remain disabled. A later successful in-app
-recovery may reopen a fresh empty session queue.
+## Durable transaction contract
 
-### Operation recovery module
-
-One deep module owns the durable journal and recovery state machine. Callers
-can begin a protected group mutation, advance durable stages, commit it, or
-recover the unfinished operation. Callers do not read or edit journal files.
-
-The journal is stored separately from authority files and
-`.skillflow-migration.json`. It contains an operation identifier, operation
-kind, source identifier, phase, managed checkout recovery paths, the authority
-snapshot needed for compensation, and owned-target fingerprints and recovery
-paths.
-
-Journal writes use the repository's normal atomic file replacement guarantees.
-They do not promise file-and-directory fsync durability across sudden power
-loss.
-
-### Helper cancellation
-
-BridgeClient owns a registry of the active helper for protected operations.
-Application termination sends cooperative termination and waits up to five
-seconds. If the helper remains alive, the whole process group is killed so Git
-or archive grandchildren do not continue after the desktop exits.
-
-The registry also latches termination before a protected helper starts. If a
-short non-protected mutation currently owns the Serial Mutation Channel, it is
-allowed to finish normally; the queued Update or Import is then rejected before
-launch instead of killing the unrelated helper.
-
-There is no public bridge command change. The Node bridge handles termination
-inside the running helper; bootstrap invokes recovery before normal workspace
-cleanup.
-
-### Application termination
-
-An AppKit termination coordinator returns `terminateLater` only when a
-protected Group Operation is active. It freezes the queue, presents a stopping
-and recovery state, and replies to the pending termination request after
-recovery succeeds. Failure keeps the application open with Retry Recovery and
-Cancel Quit actions. Cancel Quit leaves a visible Recovery Required state and
-keeps Update and Import disabled; a later Quit cannot bypass the unfinished
-journal.
-
-## Per-group commit contract
-
-A managed group is committed only when all of the following describe the same
-version:
+A managed group commits only when these describe the same version:
 
 1. canonical managed checkout;
 2. manifest and lock authority state;
 3. Skill Flow-owned target projections.
 
-Bulk Update remains one bridge command and one desktop Group Operation. The
-runtime advances one source through the complete per-group transaction before
-starting the next source. On cancellation, earlier committed sources remain;
-the current source is recovered.
+Bulk Update performs one complete transaction per source. Before the first
+transaction, the runtime preflights the entire selected source list. Therefore
+an invalid later source cannot leave earlier sources updated. Once preflight
+succeeds, earlier committed sources remain committed if a later source is
+interrupted; only the current source is recovered.
 
-Final Import uses the same commit contract. If no source existed before the
-operation, recovery removes the incomplete managed source registration and its
-owned projections while restoring any managed path moved aside by the import.
+Final Import has the same contract. Recovery removes an incomplete new source
+registration and owned projections while restoring the prepared checkout.
 
-## Ownership and conflicts
+## Journal ownership and validation
 
-- Managed checkout validation from the Git source update boundary remains
-  mandatory before staging, replacement, or recovery.
-- `ownership: "external"` sources never enter this transaction path.
-- Target directories are projections, not authority. Recovery evidence covers
-  only paths the planner classified as Skill Flow-owned.
-- Before restoring an owned target, recovery compares its current fingerprint
-  with the value produced by the interrupted operation. A mismatch is a
-  recovery conflict and is never overwritten automatically.
+The private `recovery/active.json` journal is separate from authority files and
+`.skillflow-migration.json`. It records an operation/source identity, managed
+source kind, phase, validated authority snapshot, checkout ownership, target
+IDs and ownership, fingerprints, backups, and any prior import-preparation
+record. It stores compensation evidence, never resumable work.
 
-## Bootstrap ordering
+Before reading fingerprints, deleting, moving, or restoring any journal path,
+recovery validates the complete journal:
 
-Bootstrap performs these steps in order:
+- the authority snapshot satisfies current state invariants;
+- source kind is managed (`git`, `local`, or `clawhub`), matches the source, and
+  is not external or a collection;
+- checkout identity resolves to the canonical managed checkout and agrees with
+  lock authority;
+- every target belongs to its recorded target ID and is inside that target's
+  currently re-detected built-in or custom root;
+- an import-preparation checkout equals the cache path assigned to its
+  preparation ID and matches the journal source identity.
 
-1. acquire the mutation lock, reclaiming a dead helper's lock by the existing
-   PID rules;
-2. inspect and recover any unfinished operation journal;
-3. stop with a structured recovery conflict if compensation cannot complete;
-4. only then run missing-checkout pruning and ordinary bootstrap reconciliation.
+Invalid structure returns `RECOVERY_JOURNAL_INVALID`; invalid semantic path
+ownership returns `RECOVERY_PATH_OWNERSHIP_INVALID`. Neither case supplies a
+path to cleanup code. Target fingerprints are then checked as a second guard;
+an external mismatch returns `RECOVERY_TARGET_CONFLICT` and is not overwritten.
+Journal replacement is atomic but does not claim file-and-directory fsync
+durability across sudden power loss.
 
-Successful recovery deletes operation backups and the journal. It never
-re-enqueues or resumes the interrupted operation. When the user previously
-cancelled Quit, success also clears the desktop cancellation latch and opens a
-fresh empty queue so new work can be requested normally.
+## Recovery and migration ordering
 
-## Compatibility updates
+Under the schema-independent mutation lock, bootstrap/recovery performs:
 
-- ADR 0002's v1 `no cancel` decision is superseded only for application Quit.
-- The import timeout design's OS-cleanup fallback is superseded by process-group
-  termination for protected operations.
-- Git update time budgets remain unchanged; application Quit has its own
-  five-second cooperative cancellation grace period.
-- Bridge protocol 1.0 command names and payloads remain unchanged.
+1. read and validate the whole journal and authority snapshot;
+2. stop/clean interrupted disposable preparations;
+3. verify every owned-target fingerprint;
+4. restore the managed checkout;
+5. restore authority state;
+6. restore owned targets and any prior preparation record;
+7. clear backups and journal;
+8. only then prune missing checkouts and reconcile normally.
+
+State migration follows the same boundary. Dry-run migration is strictly
+read-only and does not acquire the lock or recover. For current V2 state,
+migration entry first recovers an active journal before reporting that state is
+current. A V1 state plus an active journal is an inconsistent unsupported
+combination and migration stops without changing either file. Normal bootstrap
+still performs its recovery check, making recovery idempotent across entry
+points.
+
+## Compatibility
+
+- ADR 0002's `no cancel` decision is superseded only for application Quit.
+- Existing timeout budgets stay unchanged; Quit has its own five-second group
+  cancellation grace period.
+- Bridge protocol command names and payload shapes remain unchanged.
+- CLI/TUI flows and external-source lifecycle behavior remain unchanged, while
+  shared managed transaction and recovery invariants apply wherever invoked.
 
 ## Acceptance tests
 
-1. Queue shutdown drops Queued operations and cannot restart draining until a
-   recovery succeeds after the user has cancelled Quit; reopening starts with
-   an empty queue and never replays the interrupted work.
-2. Quit with no protected operation terminates immediately.
-3. Quit with a Running operation enters delayed termination and displays
-   stopping/recovery feedback.
-4. A cooperative helper exits during the grace period without forced kill.
-5. An unresponsive helper and its descendant process are terminated after the
-   grace period.
-6. Cancellation before and after every checkout replacement stage restores the
-   previous managed group.
-7. Cancellation during authority promotion or target deployment restores the
-   previous managed group.
-8. Bulk Update preserves previously committed groups and restores only the
-   current incomplete group.
-9. Final Import recovery removes an incomplete new group and restores owned
-   target paths.
-10. Import preparation cancellation cleans interrupted preparation while
-    preserving reusable Ready preparation records.
-11. A target fingerprint mismatch blocks recovery without overwriting the path.
-12. Bootstrap recovers an unfinished journal before missing-checkout pruning.
-13. Recovery success clears backups and journal; failure keeps protected
-    mutations disabled and supports retry.
+1. Queue shutdown drops Queued work and cannot restart until durable recovery
+   succeeds; no interrupted work is replayed.
+2. Quit is immediate with no protected queue work or cancellable helper.
+3. Durable, preparation, preview, search, and local-scan helpers delay Quit and
+   are all terminated, including descendants, before durable recovery.
+4. Disposable-only cleanup failure still permits Quit and is retried by the
+   next bootstrap.
+5. Ordinary helper timeout retains helper-only termination semantics.
+6. Whole-list Bulk Update preflight occurs before the first journal/mutation;
+   after it passes, compensation remains per group.
+7. Cancellation at checkout, authority, or deployment stages restores only the
+   incomplete managed group.
+8. Final Import restores its Ready preparation and removes incomplete managed
+   state.
+9. Recovery rejects invalid authority, checkout, preparation, or target
+   ownership before touching any recorded path.
+10. A target fingerprint conflict is retained for explicit recovery.
+11. V2 migration entry recovers first; V1 plus journal is blocked; dry-run is
+    read-only.
+12. Recovery Required permits search/scan/preview but blocks preparation,
+    final Import, and Update.
+
+## Confirmed decision record
+
+- Q13-A: restore checkout, authority, then owned targets.
+- Q14-A: recovery runs before ordinary bootstrap pruning/reconciliation.
+- Q15-A: ordinary timeout remains helper-only; process-group kill is Quit-only.
+- Q16-A: Bulk Update preflights the complete selection before per-group work.
+- Q17-A: helpers are classified as durable, preparation, disposable query, or
+  unrelated.
+- Q18-A: disposable helpers also delay Quit and are cancelled/cleaned first.
+- Q19-A: Quit uses TERM, a five-second grace period, then group kill.
+- Q20-A: Recovery Required allows discovery queries but blocks preparation and
+  durable mutations.
+- Q21-A: disposable cleanup failure does not block Quit.
+- Q22-A: all cancellable helpers stop before durable recovery.

--- a/packages/core-engine/src/index.ts
+++ b/packages/core-engine/src/index.ts
@@ -3,6 +3,7 @@ export * from "./services/deployment-planner.js";
 export * from "./services/doctor-service.js";
 export * from "./services/external-source-lifecycle.js";
 export * from "./services/inventory-service.js";
+export * from "./services/operation-recovery-service.js";
 export * from "./services/recent-project-service.js";
 export * from "./services/state-migration-service.js";
 export * from "./services/source-types.js";

--- a/packages/core-engine/src/services/operation-recovery-service.ts
+++ b/packages/core-engine/src/services/operation-recovery-service.ts
@@ -1,0 +1,391 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { DeploymentAction, Result } from "@skill-flow/domain/types";
+import { copyDirectory, pathExists, removePath } from "@skill-flow/integration/utils/fs";
+import { fail, ok } from "@skill-flow/integration/utils/result";
+import {
+  RecoveryJournalStore,
+  type RecoveryJournal,
+  type RecoveryOperationKind,
+  type RecoveryPathSnapshot,
+} from "@skill-flow/storage/recovery-journal-store";
+import type { StateStore } from "@skill-flow/storage/state-store";
+import type { ImportPreparationCacheStore } from "@skill-flow/storage/import-preparation-cache-store";
+
+export type OperationRecoveryServiceOptions = {
+  stateStore: StateStore;
+  cacheStore?: ImportPreparationCacheStore;
+};
+
+export type RecoveryResult = {
+  recovered: boolean;
+  sourceId?: string;
+  kind?: RecoveryOperationKind;
+};
+
+/**
+ * Owns the durable recovery transaction for one managed source operation.
+ * Callers only begin, checkpoint after filesystem mutation, and commit.
+ */
+export class OperationRecoveryService {
+  private readonly journalStore: RecoveryJournalStore;
+
+  constructor(private readonly options: OperationRecoveryServiceOptions) {
+    this.journalStore = new RecoveryJournalStore(options.stateStore.rootPath);
+  }
+
+  async begin(input: {
+    kind: RecoveryOperationKind;
+    sourceId: string;
+    checkoutPath?: string;
+    preparationId?: string;
+  }): Promise<{ checkoutBackupPath?: string }> {
+    const existing = await this.journalStore.read();
+    if (existing) {
+      throw new Error(
+        `Recovery transaction '${existing.transactionId}' must be recovered before starting another operation.`,
+      );
+    }
+    const authorityBefore = await this.options.stateStore.readState();
+    const importPreparationBefore = input.preparationId && this.options.cacheStore
+      ? (await this.options.cacheStore.readImportPreparationCache()).records[input.preparationId]
+      : undefined;
+    const sourceLock = authorityBefore.lockFile.sources[input.sourceId];
+    if (
+      authorityBefore.manifest.sources.find((source) => source.id === input.sourceId)?.ownership === "external"
+      || sourceLock?.ownership === "external"
+    ) {
+      throw new Error(`Refusing to create a recovery transaction for externally managed source '${input.sourceId}'.`);
+    }
+
+    const transactionId = `recovery-${process.pid}-${crypto.randomUUID()}`;
+    const checkoutPath = input.checkoutPath ?? sourceLock?.localPath;
+    const checkoutBackupPath = checkoutPath
+      ? this.journalStore.backupPath(transactionId, "checkout")
+      : undefined;
+    if (checkoutBackupPath) {
+      await fs.mkdir(path.dirname(checkoutBackupPath), { recursive: true });
+    }
+    const checkout = checkoutPath
+      ? {
+          path: checkoutPath,
+          existed: await pathExists(checkoutPath),
+          backupName: "checkout",
+          beforeFingerprint: "managed-checkout",
+        }
+      : undefined;
+    await this.journalStore.write({
+      schemaVersion: 1,
+      transactionId,
+      kind: input.kind,
+      sourceId: input.sourceId,
+      startedAt: new Date().toISOString(),
+      phase: "prepared",
+      authorityBefore,
+      ...(importPreparationBefore ? { importPreparationBefore } : {}),
+      ...(checkout ? { checkout } : {}),
+      targets: [],
+    });
+    return checkout && checkoutBackupPath
+      ? { checkoutBackupPath }
+      : {};
+  }
+
+  async prepareTargetMutations(actions: DeploymentAction[]): Promise<void> {
+    const journal = await this.requireJournal();
+    const knownTargets = new Map(journal.targets.map((target) => [path.resolve(target.path), target]));
+    for (const action of actions.filter((candidate) =>
+      candidate.kind !== "noop"
+      && candidate.kind !== "blocked"
+    )) {
+      const transitions: Array<{ targetPath: string; expected: string }> = [];
+      if (action.kind === "remove") {
+        transitions.push({ targetPath: action.targetPath, expected: "missing" });
+      } else {
+        transitions.push({
+          targetPath: action.targetPath,
+          expected: action.strategy === "symlink"
+            ? fingerprintSymlink(action.sourcePath)
+            : await fingerprintPath(action.sourcePath),
+        });
+      }
+      if (action.previousTargetPath && action.previousTargetPath !== action.targetPath) {
+        transitions.push({ targetPath: action.previousTargetPath, expected: "missing" });
+      }
+      if (action.relocateExternalToTargetPath) {
+        transitions.push({
+          targetPath: action.relocateExternalToTargetPath,
+          expected: await fingerprintPath(action.targetPath),
+        });
+      }
+      for (const transition of transitions) {
+        const resolved = path.resolve(transition.targetPath);
+        let snapshot = knownTargets.get(resolved);
+        if (!snapshot) {
+          snapshot = await this.snapshotPath(
+            journal.transactionId,
+            `target-${knownTargets.size}`,
+            transition.targetPath,
+          );
+        }
+        knownTargets.set(resolved, {
+          ...snapshot,
+          mutationFingerprint: transition.expected,
+          allowedMutationFingerprints: [
+            ...new Set([
+              ...(snapshot.allowedMutationFingerprints ?? []),
+              transition.expected,
+            ]),
+          ],
+        });
+      }
+    }
+    await this.journalStore.write({
+      ...journal,
+      phase: "mutated",
+      targets: [...knownTargets.values()],
+    });
+  }
+
+  async prepareManagedSymlinkMutation(targetPath: string, sourcePath: string): Promise<void> {
+    const journal = await this.requireJournal();
+    if (journal.targets.some((target) => path.resolve(target.path) === path.resolve(targetPath))) {
+      return;
+    }
+    const snapshot = await this.snapshotPath(
+      journal.transactionId,
+      `target-${journal.targets.length}`,
+      targetPath,
+    );
+    await this.journalStore.write({
+      ...journal,
+      phase: "mutated",
+      targets: [
+        ...journal.targets,
+        {
+          ...snapshot,
+          mutationFingerprint: fingerprintSymlink(sourcePath),
+          allowedMutationFingerprints: [fingerprintSymlink(sourcePath)],
+        },
+      ],
+    });
+  }
+
+  async checkpoint(): Promise<void> {
+    const journal = await this.requireJournal();
+    const conflict = await this.findTargetConflict(journal);
+    if (conflict) {
+      throw new Error(`Managed target '${conflict}' changed outside the active operation.`);
+    }
+  }
+
+  async commit(): Promise<void> {
+    const journal = await this.requireJournal();
+    await this.journalStore.clear(journal);
+  }
+
+  async recover(): Promise<Result<RecoveryResult>> {
+    try {
+      await this.cleanupInterruptedPreparations();
+    } catch (error) {
+      return fail({
+        code: "IMPORT_PREPARATION_RECOVERY_FAILED",
+        message: `Unable to clean interrupted import preparation: ${String(error)}`,
+      });
+    }
+    let journal: RecoveryJournal | undefined;
+    try {
+      journal = await this.journalStore.read();
+    } catch (error) {
+      return fail({
+        code: "RECOVERY_JOURNAL_INVALID",
+        message: `Unable to read the interrupted-operation recovery journal safely: ${String(error)}`,
+      });
+    }
+    if (!journal) return ok({ recovered: false });
+
+    const conflict = await this.findTargetConflict(journal);
+    if (conflict) {
+      return fail({
+        code: "RECOVERY_TARGET_CONFLICT",
+        message: `Recovery stopped because managed target '${conflict}' changed outside the interrupted operation.`,
+      });
+    }
+
+    try {
+      if (journal.checkout) await this.restoreCheckout(journal, journal.checkout);
+      for (const target of journal.targets) await this.restorePath(journal, target);
+      await this.options.stateStore.writeState(journal.authorityBefore);
+      if (journal.importPreparationBefore && this.options.cacheStore) {
+        await this.options.cacheStore.writeImportPreparationRecord({
+          ...journal.importPreparationBefore,
+          status: "ready",
+        });
+      }
+      await this.journalStore.clear(journal);
+      return ok({ recovered: true, sourceId: journal.sourceId, kind: journal.kind });
+    } catch (error) {
+      return fail({
+        code: "OPERATION_RECOVERY_FAILED",
+        message: `Unable to recover interrupted ${journal.kind} for '${journal.sourceId}': ${String(error)}`,
+      });
+    }
+  }
+
+  private async cleanupInterruptedPreparations(): Promise<void> {
+    if (!this.options.cacheStore) return;
+    const cache = await this.options.cacheStore.readImportPreparationCache();
+    const interrupted = Object.values(cache.records).filter((record) => record.status === "preparing");
+    for (const record of interrupted) {
+      await removePath(record.checkoutPath);
+      delete cache.records[record.id];
+    }
+    if (interrupted.length > 0) {
+      await this.options.cacheStore.writeImportPreparationCache(cache);
+    }
+  }
+
+  private async findTargetConflict(journal: RecoveryJournal): Promise<string | undefined> {
+    for (const target of journal.targets) {
+      const current = await fingerprintPath(target.path);
+      if (
+        current !== target.beforeFingerprint
+        && current !== target.mutationFingerprint
+        && !(target.allowedMutationFingerprints ?? []).includes(current)
+      ) {
+        return target.path;
+      }
+    }
+    return undefined;
+  }
+
+  private async snapshotPath(
+    transactionId: string,
+    backupName: string,
+    targetPath: string,
+  ): Promise<RecoveryPathSnapshot> {
+    const existed = await pathExists(targetPath);
+    const beforeFingerprint = await fingerprintPath(targetPath);
+    if (existed) {
+      const backupPath = this.journalStore.backupPath(transactionId, backupName);
+      await fs.mkdir(path.dirname(backupPath), { recursive: true });
+      await copyPath(targetPath, backupPath);
+    }
+    return {
+      path: targetPath,
+      existed,
+      ...(existed ? { backupName } : {}),
+      beforeFingerprint,
+    };
+  }
+
+  private async restorePath(journal: RecoveryJournal, snapshot: RecoveryPathSnapshot): Promise<void> {
+    await removePath(snapshot.path);
+    if (!snapshot.existed || !snapshot.backupName) return;
+    await copyPath(
+      this.journalStore.backupPath(journal.transactionId, snapshot.backupName),
+      snapshot.path,
+    );
+  }
+
+  private async restoreCheckout(
+    journal: RecoveryJournal,
+    snapshot: RecoveryPathSnapshot,
+  ): Promise<void> {
+    if (journal.kind === "import" && journal.importPreparationBefore) {
+      const preparedPath = journal.importPreparationBefore.checkoutPath;
+      if (await pathExists(snapshot.path)) {
+        await removePath(preparedPath);
+        await fs.mkdir(path.dirname(preparedPath), { recursive: true });
+        await fs.rename(snapshot.path, preparedPath);
+      }
+      return;
+    }
+    const backupPath = snapshot.backupName
+      ? this.journalStore.backupPath(journal.transactionId, snapshot.backupName)
+      : undefined;
+    if (backupPath && await pathExists(backupPath)) {
+      await removePath(snapshot.path);
+      await fs.mkdir(path.dirname(snapshot.path), { recursive: true });
+      await fs.rename(backupPath, snapshot.path);
+      return;
+    }
+    if (!snapshot.existed) {
+      await removePath(snapshot.path);
+    }
+  }
+
+  private async requireJournal(): Promise<RecoveryJournal> {
+    const journal = await this.journalStore.read();
+    if (!journal) throw new Error("No active recovery transaction.");
+    return journal;
+  }
+}
+
+async function copyPath(sourcePath: string, targetPath: string): Promise<void> {
+  const stats = await fs.lstat(sourcePath);
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  if (stats.isSymbolicLink()) {
+    await fs.symlink(await fs.readlink(sourcePath), targetPath);
+  } else if (stats.isDirectory()) {
+    await copyDirectory(sourcePath, targetPath);
+  } else {
+    await fs.copyFile(sourcePath, targetPath);
+  }
+}
+
+async function fingerprintPath(targetPath: string): Promise<string> {
+  let stats;
+  try {
+    stats = await fs.lstat(targetPath);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return "missing";
+    }
+    throw error;
+  }
+  const hash = crypto.createHash("sha256");
+  if (stats.isSymbolicLink()) {
+    hash.update("symlink\0");
+    hash.update(await fs.readlink(targetPath));
+  } else if (stats.isDirectory()) {
+    hash.update("directory\0");
+    hash.update(await hashDirectoryIncludingSymlinks(targetPath));
+  } else {
+    hash.update("file\0");
+    hash.update(await fs.readFile(targetPath));
+  }
+  return hash.digest("hex");
+}
+
+function fingerprintSymlink(sourcePath: string): string {
+  const hash = crypto.createHash("sha256");
+  hash.update("symlink\0");
+  hash.update(sourcePath);
+  return hash.digest("hex");
+}
+
+async function hashDirectoryIncludingSymlinks(root: string): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  async function walk(current: string): Promise<void> {
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      hash.update(path.relative(root, entryPath));
+      if (entry.isDirectory()) {
+        hash.update("directory");
+        await walk(entryPath);
+      } else if (entry.isSymbolicLink()) {
+        hash.update("symlink");
+        hash.update(await fs.readlink(entryPath));
+      } else {
+        hash.update("file");
+        hash.update(await fs.readFile(entryPath));
+      }
+    }
+  }
+  await walk(root);
+  return hash.digest("hex");
+}

--- a/packages/core-engine/src/services/operation-recovery-service.ts
+++ b/packages/core-engine/src/services/operation-recovery-service.ts
@@ -95,7 +95,7 @@ export class OperationRecoveryService {
           path: checkoutPath,
           existed: await pathExists(checkoutPath),
           backupName: "checkout",
-          beforeFingerprint: "managed-checkout",
+          beforeFingerprint: await fingerprintPath(checkoutPath),
         }
       : undefined;
     await this.journalStore.write({
@@ -319,6 +319,7 @@ export class OperationRecoveryService {
       if (lock && path.resolve(lock.localPath) !== checkout.data.checkoutPath) {
         throw new Error(`checkout '${journal.checkout.path}' does not match authority`);
       }
+      await this.validateSnapshotBackup(journal, journal.checkout);
     }
 
     if (journal.importPreparationBefore) {
@@ -344,6 +345,30 @@ export class OperationRecoveryService {
       const currentRoot = target.target ? targetRoots.get(target.target) : undefined;
       if (!currentRoot || !isPathInside(currentRoot, target.path)) {
         throw new Error(`target '${target.path}' is outside the current root for '${target.target ?? "unknown"}'`);
+      }
+      await this.validateSnapshotBackup(journal, target);
+    }
+  }
+
+  private async validateSnapshotBackup(
+    journal: RecoveryJournal,
+    snapshot: RecoveryPathSnapshot,
+  ): Promise<void> {
+    if (!snapshot.existed) return;
+    if (!snapshot.backupName) {
+      throw new Error(`recovery backup is missing for '${snapshot.path}'`);
+    }
+    const backupPath = this.journalStore.backupPath(journal.transactionId, snapshot.backupName);
+    if (!(await pathExists(backupPath))) {
+      if (snapshot.beforeFingerprint && await fingerprintPath(snapshot.path) === snapshot.beforeFingerprint) {
+        return;
+      }
+      throw new Error(`recovery backup does not exist for '${snapshot.path}'`);
+    }
+    if (snapshot.beforeFingerprint) {
+      const backupFingerprint = await fingerprintPath(backupPath);
+      if (backupFingerprint !== snapshot.beforeFingerprint) {
+        throw new Error(`recovery backup fingerprint does not match '${snapshot.path}'`);
       }
     }
   }
@@ -402,6 +427,12 @@ export class OperationRecoveryService {
   }
 
   private async restorePath(journal: RecoveryJournal, snapshot: RecoveryPathSnapshot): Promise<void> {
+    const backupPath = snapshot.backupName
+      ? this.journalStore.backupPath(journal.transactionId, snapshot.backupName)
+      : undefined;
+    if (snapshot.existed && backupPath && !(await pathExists(backupPath))) {
+      return;
+    }
     await removePath(snapshot.path);
     if (!snapshot.existed || !snapshot.backupName) return;
     await copyPath(
@@ -420,6 +451,8 @@ export class OperationRecoveryService {
         await removePath(preparedPath);
         await fs.mkdir(path.dirname(preparedPath), { recursive: true });
         await fs.rename(snapshot.path, preparedPath);
+      } else if (!(await pathExists(preparedPath))) {
+        throw new Error(`Prepared import checkout '${preparedPath}' is unavailable for recovery.`);
       }
       return;
     }
@@ -430,6 +463,9 @@ export class OperationRecoveryService {
       await removePath(snapshot.path);
       await fs.mkdir(path.dirname(snapshot.path), { recursive: true });
       await fs.rename(backupPath, snapshot.path);
+      return;
+    }
+    if (backupPath && snapshot.beforeFingerprint && await fingerprintPath(snapshot.path) === snapshot.beforeFingerprint) {
       return;
     }
     if (!snapshot.existed) {

--- a/packages/core-engine/src/services/operation-recovery-service.ts
+++ b/packages/core-engine/src/services/operation-recovery-service.ts
@@ -59,7 +59,7 @@ export class OperationRecoveryService {
     sourceKind: SourceKind;
     checkoutPath?: string;
     preparationId?: string;
-  }): Promise<{ checkoutBackupPath?: string }> {
+  }): Promise<{ checkoutBackupPath: string }> {
     const existing = await this.journalStore.read();
     if (existing) {
       throw new Error(
@@ -87,39 +87,40 @@ export class OperationRecoveryService {
 
     const transactionId = `recovery-${process.pid}-${crypto.randomUUID()}`;
     const checkoutPath = input.checkoutPath ?? sourceLock?.localPath;
-    const checkoutBackupPath = checkoutPath
-      ? this.journalStore.backupPath(transactionId, "checkout")
-      : undefined;
-    if (checkoutBackupPath) {
-      await fs.mkdir(path.dirname(checkoutBackupPath), { recursive: true });
+    if (!checkoutPath) {
+      throw new Error(`Refusing to create a recovery transaction without a managed checkout for '${input.sourceId}'.`);
     }
-    const checkout = checkoutPath
-      ? {
-          role: "checkout" as const,
-          sourceId: input.sourceId,
-          sourceKind: input.sourceKind,
-          path: checkoutPath,
-          existed: await pathExists(checkoutPath),
-          backupName: "checkout",
-          beforeFingerprint: await fingerprintPath(checkoutPath),
-        }
-      : undefined;
-    await this.journalStore.write({
-      schemaVersion: 1,
+    const checkoutBackupPath = this.journalStore.backupPath(transactionId, "checkout");
+    await fs.mkdir(path.dirname(checkoutBackupPath), { recursive: true });
+    const checkout = {
+      role: "checkout" as const,
+      sourceId: input.sourceId,
+      sourceKind: input.sourceKind,
+      path: checkoutPath,
+      existed: await pathExists(checkoutPath),
+      backupName: "checkout",
+      beforeFingerprint: await fingerprintPath(checkoutPath),
+    };
+    const journalBase = {
+      schemaVersion: 1 as const,
       transactionId,
-      kind: input.kind,
       sourceId: input.sourceId,
       sourceKind: input.sourceKind,
       startedAt: new Date().toISOString(),
-      phase: "prepared",
+      phase: "prepared" as const,
       authorityBefore,
-      ...(importPreparationBefore ? { importPreparationBefore } : {}),
-      ...(checkout ? { checkout } : {}),
+      checkout,
       targets: [],
-    });
-    return checkout && checkoutBackupPath
-      ? { checkoutBackupPath }
-      : {};
+    };
+    if (input.kind === "import") {
+      if (!importPreparationBefore) {
+        throw new Error(`Refusing to create an import recovery transaction without preparation evidence for '${input.sourceId}'.`);
+      }
+      await this.journalStore.write({ ...journalBase, kind: "import", importPreparationBefore });
+    } else {
+      await this.journalStore.write({ ...journalBase, kind: "update" });
+    }
+    return { checkoutBackupPath };
   }
 
   async prepareTargetMutations(actions: DeploymentAction[]): Promise<void> {
@@ -304,15 +305,13 @@ export class OperationRecoveryService {
   }
 
   private async validateRecoveryPathOwnership(journal: RecoveryJournal): Promise<void> {
+    const backupSnapshots: RecoveryPathSnapshot[] = [];
     const source = journal.authorityBefore.manifest.sources.find(
       (candidate) => candidate.id === journal.sourceId,
     );
     const lock = journal.authorityBefore.lockFile.sources[journal.sourceId];
     if (journal.kind === "update" && (!source || !lock)) {
       throw new Error(`update source '${journal.sourceId}' is missing from authority`);
-    }
-    if (journal.kind === "import" && !journal.importPreparationBefore) {
-      throw new Error(`import source '${journal.sourceId}' is missing preparation evidence`);
     }
     if (source && (
       source.kind === "collection"
@@ -325,21 +324,19 @@ export class OperationRecoveryService {
       throw new Error(`source '${journal.sourceId}' is not a matching managed source`);
     }
 
-    if (journal.checkout) {
-      const checkout = await resolveManagedCheckoutOwnership({
-        stateRoot: this.options.stateStore.rootPath,
-        sourceKind: journal.sourceKind,
-        sourceId: journal.sourceId,
-        localPath: journal.checkout.path,
-      });
-      if (!checkout.ok) {
-        throw new Error(`checkout '${journal.checkout.path}' is not canonically managed`);
-      }
-      if (lock && path.resolve(lock.localPath) !== checkout.data.checkoutPath) {
-        throw new Error(`checkout '${journal.checkout.path}' does not match authority`);
-      }
-      await this.validateSnapshotBackup(journal, journal.checkout);
+    const checkout = await resolveManagedCheckoutOwnership({
+      stateRoot: this.options.stateStore.rootPath,
+      sourceKind: journal.sourceKind,
+      sourceId: journal.sourceId,
+      localPath: journal.checkout.path,
+    });
+    if (!checkout.ok) {
+      throw new Error(`checkout '${journal.checkout.path}' is not canonically managed`);
     }
+    if (lock && path.resolve(lock.localPath) !== checkout.data.checkoutPath) {
+      throw new Error(`checkout '${journal.checkout.path}' does not match authority`);
+    }
+    backupSnapshots.push(journal.checkout);
 
     if (journal.importPreparationBefore) {
       if (!this.options.cacheStore) {
@@ -357,16 +354,18 @@ export class OperationRecoveryService {
       }
     }
 
-    if (journal.targets.length === 0) return;
-    const targetRoots = await this.options.resolveTargetRoots?.();
-    if (!targetRoots) throw new Error("current target roots are unavailable");
-    for (const target of journal.targets) {
-      const currentRoot = target.target ? targetRoots.get(target.target) : undefined;
-      if (!currentRoot || !isPathInside(currentRoot, target.path)) {
-        throw new Error(`target '${target.path}' is outside the current root for '${target.target ?? "unknown"}'`);
+    if (journal.targets.length > 0) {
+      const targetRoots = await this.options.resolveTargetRoots?.();
+      if (!targetRoots) throw new Error("current target roots are unavailable");
+      for (const target of journal.targets) {
+        const currentRoot = target.target ? targetRoots.get(target.target) : undefined;
+        if (!currentRoot || !isPathInside(currentRoot, target.path)) {
+          throw new Error(`target '${target.path}' is outside the current root for '${target.target ?? "unknown"}'`);
+        }
+        backupSnapshots.push(target);
       }
-      await this.validateSnapshotBackup(journal, target);
     }
+    for (const snapshot of backupSnapshots) await this.validateSnapshotBackup(journal, snapshot);
   }
 
   private async validateSnapshotBackup(
@@ -443,19 +442,23 @@ export class OperationRecoveryService {
     };
   }
 
-  private async restorePath(journal: RecoveryJournal, snapshot: RecoveryPathSnapshot): Promise<void> {
-    const backupPath = snapshot.backupName
-      ? this.journalStore.backupPath(journal.transactionId, snapshot.backupName)
-      : undefined;
-    if (snapshot.existed && backupPath && !(await pathExists(backupPath))) {
+  private async restorePath(journal: RecoveryJournal, snapshot: RecoveryTargetSnapshot): Promise<void> {
+    if (!snapshot.existed) {
+      await removePath(snapshot.path);
       return;
     }
+    if (!snapshot.backupName) {
+      throw new Error(`recovery backup is missing for '${snapshot.path}'`);
+    }
+    const backupPath = this.journalStore.backupPath(journal.transactionId, snapshot.backupName);
+    if (!(await pathExists(backupPath))) {
+      if (await fingerprintPath(snapshot.path) === snapshot.beforeFingerprint) {
+        return;
+      }
+      throw new Error(`recovery backup does not exist for '${snapshot.path}'`);
+    }
     await removePath(snapshot.path);
-    if (!snapshot.existed || !snapshot.backupName) return;
-    await copyPath(
-      this.journalStore.backupPath(journal.transactionId, snapshot.backupName),
-      snapshot.path,
-    );
+    await copyPath(backupPath, snapshot.path);
   }
 
   private async restoreCheckout(

--- a/packages/core-engine/src/services/operation-recovery-service.ts
+++ b/packages/core-engine/src/services/operation-recovery-service.ts
@@ -18,6 +18,7 @@ import {
   RecoveryJournalStore,
   type RecoveryJournal,
   type RecoveryOperationKind,
+  type RecoveryTargetSnapshot,
   type RecoveryPathSnapshot,
 } from "@skill-flow/storage/recovery-journal-store";
 import type { StateStore } from "@skill-flow/storage/state-store";
@@ -35,6 +36,11 @@ export type RecoveryResult = {
   sourceId?: string;
   kind?: RecoveryOperationKind;
 };
+
+type RecoveryTargetSnapshotDraft = Omit<
+  RecoveryTargetSnapshot,
+  "mutationFingerprint" | "allowedMutationFingerprints"
+>;
 
 /**
  * Owns the durable recovery transaction for one managed source operation.
@@ -147,7 +153,7 @@ export class OperationRecoveryService {
         const resolved = path.resolve(transition.targetPath);
         let snapshot = knownTargets.get(resolved);
         if (!snapshot) {
-          snapshot = await this.snapshotPath(
+          const draft = await this.snapshotTargetPath(
             journal.transactionId,
             `target-${knownTargets.size}`,
             transition.targetPath,
@@ -157,6 +163,10 @@ export class OperationRecoveryService {
               target: action.target,
             },
           );
+          snapshot = {
+            ...draft,
+            mutationFingerprint: transition.expected,
+          };
         }
         if (
           snapshot.role !== "target"
@@ -193,7 +203,7 @@ export class OperationRecoveryService {
     if (journal.targets.some((target) => path.resolve(target.path) === path.resolve(targetPath))) {
       return;
     }
-    const snapshot = await this.snapshotPath(
+    const snapshot = await this.snapshotTargetPath(
       journal.transactionId,
       `target-${journal.targets.length}`,
       targetPath,
@@ -298,11 +308,20 @@ export class OperationRecoveryService {
       (candidate) => candidate.id === journal.sourceId,
     );
     const lock = journal.authorityBefore.lockFile.sources[journal.sourceId];
-    if (
-      source?.ownership === "external"
-      || lock?.ownership === "external"
-      || (source && source.kind !== journal.sourceKind)
-    ) {
+    if (journal.kind === "update" && (!source || !lock)) {
+      throw new Error(`update source '${journal.sourceId}' is missing from authority`);
+    }
+    if (journal.kind === "import" && !journal.importPreparationBefore) {
+      throw new Error(`import source '${journal.sourceId}' is missing preparation evidence`);
+    }
+    if (source && (
+      source.kind === "collection"
+      || source.ownership === "external"
+      || source.kind !== journal.sourceKind
+    )) {
+      throw new Error(`source '${journal.sourceId}' is not a matching managed source`);
+    }
+    if (lock?.ownership === "external") {
       throw new Error(`source '${journal.sourceId}' is not a matching managed source`);
     }
 
@@ -360,16 +379,14 @@ export class OperationRecoveryService {
     }
     const backupPath = this.journalStore.backupPath(journal.transactionId, snapshot.backupName);
     if (!(await pathExists(backupPath))) {
-      if (snapshot.beforeFingerprint && await fingerprintPath(snapshot.path) === snapshot.beforeFingerprint) {
+      if (await fingerprintPath(snapshot.path) === snapshot.beforeFingerprint) {
         return;
       }
       throw new Error(`recovery backup does not exist for '${snapshot.path}'`);
     }
-    if (snapshot.beforeFingerprint) {
-      const backupFingerprint = await fingerprintPath(backupPath);
-      if (backupFingerprint !== snapshot.beforeFingerprint) {
-        throw new Error(`recovery backup fingerprint does not match '${snapshot.path}'`);
-      }
+    const backupFingerprint = await fingerprintPath(backupPath);
+    if (backupFingerprint !== snapshot.beforeFingerprint) {
+      throw new Error(`recovery backup fingerprint does not match '${snapshot.path}'`);
     }
   }
 
@@ -404,12 +421,12 @@ export class OperationRecoveryService {
     return undefined;
   }
 
-  private async snapshotPath(
+  private async snapshotTargetPath(
     transactionId: string,
     backupName: string,
     targetPath: string,
-    ownership: Pick<RecoveryPathSnapshot, "role" | "sourceId" | "sourceKind" | "target">,
-  ): Promise<RecoveryPathSnapshot> {
+    ownership: Pick<RecoveryTargetSnapshot, "role" | "sourceId" | "target">,
+  ): Promise<RecoveryTargetSnapshotDraft> {
     const existed = await pathExists(targetPath);
     const beforeFingerprint = await fingerprintPath(targetPath);
     if (existed) {
@@ -465,7 +482,7 @@ export class OperationRecoveryService {
       await fs.rename(backupPath, snapshot.path);
       return;
     }
-    if (backupPath && snapshot.beforeFingerprint && await fingerprintPath(snapshot.path) === snapshot.beforeFingerprint) {
+    if (backupPath && await fingerprintPath(snapshot.path) === snapshot.beforeFingerprint) {
       return;
     }
     if (!snapshot.existed) {

--- a/packages/core-engine/src/services/operation-recovery-service.ts
+++ b/packages/core-engine/src/services/operation-recovery-service.ts
@@ -1,8 +1,18 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { DeploymentAction, Result } from "@skill-flow/domain/types";
-import { copyDirectory, pathExists, removePath } from "@skill-flow/integration/utils/fs";
+import type {
+  DeploymentAction,
+  DeploymentTargetId,
+  Result,
+  SourceKind,
+} from "@skill-flow/domain/types";
+import {
+  copyDirectory,
+  isPathInside,
+  pathExists,
+  removePath,
+} from "@skill-flow/integration/utils/fs";
 import { fail, ok } from "@skill-flow/integration/utils/result";
 import {
   RecoveryJournalStore,
@@ -12,10 +22,12 @@ import {
 } from "@skill-flow/storage/recovery-journal-store";
 import type { StateStore } from "@skill-flow/storage/state-store";
 import type { ImportPreparationCacheStore } from "@skill-flow/storage/import-preparation-cache-store";
+import { resolveManagedCheckoutOwnership } from "../internal/managed-checkout-policy.js";
 
 export type OperationRecoveryServiceOptions = {
   stateStore: StateStore;
   cacheStore?: ImportPreparationCacheStore;
+  resolveTargetRoots?: () => Promise<Map<DeploymentTargetId, string>>;
 };
 
 export type RecoveryResult = {
@@ -38,6 +50,7 @@ export class OperationRecoveryService {
   async begin(input: {
     kind: RecoveryOperationKind;
     sourceId: string;
+    sourceKind: SourceKind;
     checkoutPath?: string;
     preparationId?: string;
   }): Promise<{ checkoutBackupPath?: string }> {
@@ -52,6 +65,13 @@ export class OperationRecoveryService {
       ? (await this.options.cacheStore.readImportPreparationCache()).records[input.preparationId]
       : undefined;
     const sourceLock = authorityBefore.lockFile.sources[input.sourceId];
+    const sourceManifest = authorityBefore.manifest.sources.find((source) => source.id === input.sourceId);
+    if (
+      input.sourceKind === "collection"
+      || (sourceManifest && sourceManifest.kind !== input.sourceKind)
+    ) {
+      throw new Error(`Refusing to create a recovery transaction with invalid source ownership for '${input.sourceId}'.`);
+    }
     if (
       authorityBefore.manifest.sources.find((source) => source.id === input.sourceId)?.ownership === "external"
       || sourceLock?.ownership === "external"
@@ -69,6 +89,9 @@ export class OperationRecoveryService {
     }
     const checkout = checkoutPath
       ? {
+          role: "checkout" as const,
+          sourceId: input.sourceId,
+          sourceKind: input.sourceKind,
           path: checkoutPath,
           existed: await pathExists(checkoutPath),
           backupName: "checkout",
@@ -80,6 +103,7 @@ export class OperationRecoveryService {
       transactionId,
       kind: input.kind,
       sourceId: input.sourceId,
+      sourceKind: input.sourceKind,
       startedAt: new Date().toISOString(),
       phase: "prepared",
       authorityBefore,
@@ -127,7 +151,19 @@ export class OperationRecoveryService {
             journal.transactionId,
             `target-${knownTargets.size}`,
             transition.targetPath,
+            {
+              role: "target",
+              sourceId: action.sourceId,
+              target: action.target,
+            },
           );
+        }
+        if (
+          snapshot.role !== "target"
+          || snapshot.sourceId !== action.sourceId
+          || snapshot.target !== action.target
+        ) {
+          throw new Error(`Conflicting recovery ownership for managed target '${transition.targetPath}'.`);
         }
         knownTargets.set(resolved, {
           ...snapshot,
@@ -148,7 +184,11 @@ export class OperationRecoveryService {
     });
   }
 
-  async prepareManagedSymlinkMutation(targetPath: string, sourcePath: string): Promise<void> {
+  async prepareManagedSymlinkMutation(
+    targetPath: string,
+    sourcePath: string,
+    ownership: { sourceId: string; target: DeploymentTargetId },
+  ): Promise<void> {
     const journal = await this.requireJournal();
     if (journal.targets.some((target) => path.resolve(target.path) === path.resolve(targetPath))) {
       return;
@@ -157,6 +197,7 @@ export class OperationRecoveryService {
       journal.transactionId,
       `target-${journal.targets.length}`,
       targetPath,
+      { role: "target", sourceId: ownership.sourceId, target: ownership.target },
     );
     await this.journalStore.write({
       ...journal,
@@ -186,14 +227,6 @@ export class OperationRecoveryService {
   }
 
   async recover(): Promise<Result<RecoveryResult>> {
-    try {
-      await this.cleanupInterruptedPreparations();
-    } catch (error) {
-      return fail({
-        code: "IMPORT_PREPARATION_RECOVERY_FAILED",
-        message: `Unable to clean interrupted import preparation: ${String(error)}`,
-      });
-    }
     let journal: RecoveryJournal | undefined;
     try {
       journal = await this.journalStore.read();
@@ -201,6 +234,33 @@ export class OperationRecoveryService {
       return fail({
         code: "RECOVERY_JOURNAL_INVALID",
         message: `Unable to read the interrupted-operation recovery journal safely: ${String(error)}`,
+      });
+    }
+    if (journal) {
+      try {
+        this.options.stateStore.validateState(journal.authorityBefore);
+      } catch (error) {
+        return fail({
+          code: "RECOVERY_JOURNAL_INVALID",
+          message: `Recovery stopped because the authority snapshot is invalid: ${String(error)}`,
+        });
+      }
+      try {
+        await this.validateRecoveryPathOwnership(journal);
+      } catch (error) {
+        return fail({
+          code: "RECOVERY_PATH_OWNERSHIP_INVALID",
+          message: `Recovery stopped because journal path ownership could not be verified: ${String(error)}`,
+        });
+      }
+    }
+
+    try {
+      await this.cleanupInterruptedPreparations();
+    } catch (error) {
+      return fail({
+        code: "IMPORT_PREPARATION_RECOVERY_FAILED",
+        message: `Unable to clean interrupted import preparation: ${String(error)}`,
       });
     }
     if (!journal) return ok({ recovered: false });
@@ -215,8 +275,8 @@ export class OperationRecoveryService {
 
     try {
       if (journal.checkout) await this.restoreCheckout(journal, journal.checkout);
-      for (const target of journal.targets) await this.restorePath(journal, target);
       await this.options.stateStore.writeState(journal.authorityBefore);
+      for (const target of journal.targets) await this.restorePath(journal, target);
       if (journal.importPreparationBefore && this.options.cacheStore) {
         await this.options.cacheStore.writeImportPreparationRecord({
           ...journal.importPreparationBefore,
@@ -233,11 +293,70 @@ export class OperationRecoveryService {
     }
   }
 
+  private async validateRecoveryPathOwnership(journal: RecoveryJournal): Promise<void> {
+    const source = journal.authorityBefore.manifest.sources.find(
+      (candidate) => candidate.id === journal.sourceId,
+    );
+    const lock = journal.authorityBefore.lockFile.sources[journal.sourceId];
+    if (
+      source?.ownership === "external"
+      || lock?.ownership === "external"
+      || (source && source.kind !== journal.sourceKind)
+    ) {
+      throw new Error(`source '${journal.sourceId}' is not a matching managed source`);
+    }
+
+    if (journal.checkout) {
+      const checkout = await resolveManagedCheckoutOwnership({
+        stateRoot: this.options.stateStore.rootPath,
+        sourceKind: journal.sourceKind,
+        sourceId: journal.sourceId,
+        localPath: journal.checkout.path,
+      });
+      if (!checkout.ok) {
+        throw new Error(`checkout '${journal.checkout.path}' is not canonically managed`);
+      }
+      if (lock && path.resolve(lock.localPath) !== checkout.data.checkoutPath) {
+        throw new Error(`checkout '${journal.checkout.path}' does not match authority`);
+      }
+    }
+
+    if (journal.importPreparationBefore) {
+      if (!this.options.cacheStore) {
+        throw new Error("import preparation cache is unavailable");
+      }
+      const preparation = journal.importPreparationBefore;
+      const expectedPath = this.options.cacheStore.getImportPreparationCheckoutPath(preparation.id);
+      if (
+        journal.kind !== "import"
+        || preparation.sourceId !== journal.sourceId
+        || preparation.sourceKind !== journal.sourceKind
+        || path.resolve(preparation.checkoutPath) !== path.resolve(expectedPath)
+      ) {
+        throw new Error(`import preparation '${preparation.id}' has invalid ownership metadata`);
+      }
+    }
+
+    if (journal.targets.length === 0) return;
+    const targetRoots = await this.options.resolveTargetRoots?.();
+    if (!targetRoots) throw new Error("current target roots are unavailable");
+    for (const target of journal.targets) {
+      const currentRoot = target.target ? targetRoots.get(target.target) : undefined;
+      if (!currentRoot || !isPathInside(currentRoot, target.path)) {
+        throw new Error(`target '${target.path}' is outside the current root for '${target.target ?? "unknown"}'`);
+      }
+    }
+  }
+
   private async cleanupInterruptedPreparations(): Promise<void> {
     if (!this.options.cacheStore) return;
     const cache = await this.options.cacheStore.readImportPreparationCache();
     const interrupted = Object.values(cache.records).filter((record) => record.status === "preparing");
     for (const record of interrupted) {
+      const expectedPath = this.options.cacheStore.getImportPreparationCheckoutPath(record.id);
+      if (path.resolve(record.checkoutPath) !== path.resolve(expectedPath)) {
+        throw new Error(`Preparation '${record.id}' has an invalid checkout path.`);
+      }
       await removePath(record.checkoutPath);
       delete cache.records[record.id];
     }
@@ -264,6 +383,7 @@ export class OperationRecoveryService {
     transactionId: string,
     backupName: string,
     targetPath: string,
+    ownership: Pick<RecoveryPathSnapshot, "role" | "sourceId" | "sourceKind" | "target">,
   ): Promise<RecoveryPathSnapshot> {
     const existed = await pathExists(targetPath);
     const beforeFingerprint = await fingerprintPath(targetPath);
@@ -273,6 +393,7 @@ export class OperationRecoveryService {
       await copyPath(targetPath, backupPath);
     }
     return {
+      ...ownership,
       path: targetPath,
       existed,
       ...(existed ? { backupName } : {}),

--- a/packages/core-engine/src/services/source-authority-service.ts
+++ b/packages/core-engine/src/services/source-authority-service.ts
@@ -360,6 +360,21 @@ export class SourceAuthorityService {
     return this.withMutationLock(() => this.updateSourcesUnlocked(sourceIds, options));
   }
 
+  async preflightUpdateSources(sourceIds?: string[]): Promise<Result<void>> {
+    const state = await this.options.stateStore.readState();
+    const requestedIds = sourceIds?.length
+      ? [...new Set(sourceIds)]
+      : state.manifest.sources.map((source) => source.id);
+    const preflight = await this.preflightSourceUpdates(
+      state,
+      requestedIds,
+      Boolean(sourceIds?.length),
+    );
+    return preflight.ok
+      ? ok(undefined, preflight.warnings)
+      : fail(preflight.errors, preflight.warnings);
+  }
+
   private async updateSourcesUnlocked(
     sourceIds?: string[],
     options: { checkoutBackupPath?: string; retainCheckoutBackup?: boolean } = {},

--- a/packages/core-engine/src/services/source-authority-service.ts
+++ b/packages/core-engine/src/services/source-authority-service.ts
@@ -353,11 +353,17 @@ export class SourceAuthorityService {
     return ok({ removed }, warnings);
   }
 
-  async updateSources(sourceIds?: string[]): Promise<Result<SourceUpdateResult>> {
-    return this.withMutationLock(() => this.updateSourcesUnlocked(sourceIds));
+  async updateSources(
+    sourceIds?: string[],
+    options: { checkoutBackupPath?: string; retainCheckoutBackup?: boolean } = {},
+  ): Promise<Result<SourceUpdateResult>> {
+    return this.withMutationLock(() => this.updateSourcesUnlocked(sourceIds, options));
   }
 
-  private async updateSourcesUnlocked(sourceIds?: string[]): Promise<Result<SourceUpdateResult>> {
+  private async updateSourcesUnlocked(
+    sourceIds?: string[],
+    options: { checkoutBackupPath?: string; retainCheckoutBackup?: boolean } = {},
+  ): Promise<Result<SourceUpdateResult>> {
     const state = await this.options.stateStore.readState();
     const requestedIds = sourceIds?.length
       ? [...new Set(sourceIds)]
@@ -503,6 +509,8 @@ export class SourceAuthorityService {
         checkoutPath: lock.localPath,
         preparedCheckoutPath: prepared.data.checkoutPath,
         nextLockFile: candidateLockFile,
+        ...(options.checkoutBackupPath ? { backupPath: options.checkoutBackupPath } : {}),
+        retainBackup: options.retainCheckoutBackup ?? false,
       });
       if (!committed.ok) {
         hardFailures.push(...committed.errors);
@@ -591,8 +599,10 @@ export class SourceAuthorityService {
     checkoutPath: string;
     preparedCheckoutPath: string;
     nextLockFile: LockFile;
+    backupPath?: string;
+    retainBackup?: boolean;
   }): Promise<Result<void>> {
-    const backupPath = `${input.checkoutPath}.${process.pid}.${Date.now()}.backup`;
+    const backupPath = input.backupPath ?? `${input.checkoutPath}.${process.pid}.${Date.now()}.backup`;
     let previousCheckoutMoved = false;
     let preparedCheckoutMoved = false;
 
@@ -641,13 +651,15 @@ export class SourceAuthorityService {
     }
 
     const warnings: Warning[] = [];
-    try {
-      await removePath(backupPath);
-    } catch (error) {
-      warnings.push({
-        code: "SOURCE_CHECKOUT_BACKUP_CLEANUP_FAILED",
-        message: `Updated '${input.sourceId}', but failed to remove checkout backup at ${backupPath}: ${String(error)}`,
-      });
+    if (!input.retainBackup) {
+      try {
+        await removePath(backupPath);
+      } catch (error) {
+        warnings.push({
+          code: "SOURCE_CHECKOUT_BACKUP_CLEANUP_FAILED",
+          message: `Updated '${input.sourceId}', but failed to remove checkout backup at ${backupPath}: ${String(error)}`,
+        });
+      }
     }
     return ok(undefined, warnings);
   }

--- a/packages/core-engine/src/tests/operation-recovery-service.test.ts
+++ b/packages/core-engine/src/tests/operation-recovery-service.test.ts
@@ -1,0 +1,277 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { StateStore } from "@skill-flow/storage/state-store";
+import { ImportPreparationCacheStore } from "@skill-flow/storage/import-preparation-cache-store";
+import { OperationRecoveryService } from "../services/operation-recovery-service.js";
+
+describe.sequential("OperationRecoveryService", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+  });
+
+  test("recovers authority and checkout from a journal written before mutation", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const checkoutPath = path.join(stateRoot, "source", "git", "repo");
+    await fs.mkdir(checkoutPath, { recursive: true });
+    await fs.writeFile(path.join(checkoutPath, "version.txt"), "old\n", "utf8");
+
+    const original = await stateStore.readState();
+    original.manifest.sources.push({
+      id: "repo",
+      kind: "git",
+      locator: "https://example.test/repo.git",
+      canonicalLocator: "https://example.test/repo.git",
+      displayName: "repo",
+      enabled: true,
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+    });
+    original.manifest.bindings.repo = {
+      sourceId: "repo",
+      selectionMode: "selected",
+      selectedLeafIds: [],
+      enabledTargets: [],
+    };
+    original.lockFile.sources.repo = {
+      sourceId: "repo",
+      canonicalLocator: "https://example.test/repo.git",
+      revision: { provider: "git", commit: "old", capturedAt: "2026-08-22T00:00:00.000Z" },
+      localPath: checkoutPath,
+      leafIds: [],
+    };
+    await stateStore.writeState(original);
+
+    const recovery = new OperationRecoveryService({ stateStore });
+    const transaction = await recovery.begin({ kind: "update", sourceId: "repo" });
+    expect(transaction.checkoutBackupPath).toBeDefined();
+    await fs.mkdir(path.dirname(transaction.checkoutBackupPath!), { recursive: true });
+    await fs.rename(checkoutPath, transaction.checkoutBackupPath!);
+    await fs.mkdir(checkoutPath, { recursive: true });
+    await fs.writeFile(path.join(checkoutPath, "version.txt"), "new\n", "utf8");
+    const changed = await stateStore.readState();
+    changed.lockFile.sources.repo!.revision = {
+      provider: "git",
+      commit: "new",
+      capturedAt: "2026-08-22T01:00:00.000Z",
+    };
+    await stateStore.writeState(changed);
+
+    const recovered = await new OperationRecoveryService({ stateStore }).recover();
+
+    expect(recovered.ok).toBe(true);
+    if (!recovered.ok) return;
+    expect(recovered.data).toEqual({ recovered: true, sourceId: "repo", kind: "update" });
+    expect(await fs.readFile(path.join(checkoutPath, "version.txt"), "utf8")).toBe("old\n");
+    expect((await stateStore.readState()).lockFile.sources.repo?.revision).toEqual(
+      expect.objectContaining({ commit: "old" }),
+    );
+    await expect(fs.access(path.join(stateRoot, "recovery", "active.json"))).rejects.toThrow();
+  });
+
+  test("does not overwrite a managed target changed after the mutation checkpoint", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const targetPath = path.join(stateRoot, "targets", "review");
+    const sourcePath = path.join(stateRoot, "source-next", "review");
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(targetPath, "before\n", "utf8");
+    await fs.writeFile(sourcePath, "by-operation\n", "utf8");
+    const state = await stateStore.readState();
+    state.lockFile.projections.push({
+      sourceId: "repo",
+      leafId: "repo:review",
+      target: "codex",
+      targetPath,
+      targetRootPath: path.dirname(targetPath),
+      strategy: "copy",
+      status: "active",
+      contentHash: "before",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+    });
+    await stateStore.writeState(state);
+    const recovery = new OperationRecoveryService({ stateStore });
+    await recovery.begin({ kind: "update", sourceId: "repo" });
+    await recovery.prepareTargetMutations([{
+      kind: "update",
+      sourceId: "repo",
+      leafId: "repo:review",
+      target: "codex",
+      strategy: "copy",
+      sourcePath,
+      targetPath,
+      targetRootPath: path.dirname(targetPath),
+      contentHash: "by-operation",
+    }]);
+    await fs.writeFile(targetPath, "by-operation\n", "utf8");
+    await recovery.checkpoint();
+    await fs.writeFile(targetPath, "external-edit\n", "utf8");
+
+    const recovered = await recovery.recover();
+
+    expect(recovered.ok).toBe(false);
+    if (recovered.ok) return;
+    expect(recovered.errors[0]?.code).toBe("RECOVERY_TARGET_CONFLICT");
+    expect(await fs.readFile(targetPath, "utf8")).toBe("external-edit\n");
+  });
+
+  test("recovers its own target write when interrupted before the post-mutation checkpoint", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const targetPath = path.join(stateRoot, "targets", "review");
+    const sourcePath = path.join(stateRoot, "source", "git", "repo", "review");
+    await fs.mkdir(targetPath, { recursive: true });
+    await fs.writeFile(path.join(targetPath, "SKILL.md"), "before\n", "utf8");
+    await fs.mkdir(sourcePath, { recursive: true });
+    await fs.writeFile(path.join(sourcePath, "SKILL.md"), "after\n", "utf8");
+    const recovery = new OperationRecoveryService({ stateStore });
+    await recovery.begin({ kind: "update", sourceId: "repo" });
+    await recovery.prepareTargetMutations([{
+      kind: "update",
+      sourceId: "repo",
+      leafId: "repo:review",
+      target: "codex",
+      strategy: "symlink",
+      sourcePath,
+      targetPath,
+      targetRootPath: path.dirname(targetPath),
+      contentHash: "after",
+    }]);
+    await fs.rm(targetPath, { recursive: true, force: true });
+    await fs.symlink(sourcePath, targetPath);
+
+    const recovered = await recovery.recover();
+
+    expect(recovered.ok).toBe(true);
+    expect((await fs.lstat(targetPath)).isDirectory()).toBe(true);
+    expect((await fs.lstat(targetPath)).isSymbolicLink()).toBe(false);
+    expect(await fs.readFile(path.join(targetPath, "SKILL.md"), "utf8")).toBe("before\n");
+  });
+
+  test("cleans interrupted preparing content while preserving ready import cache", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const cacheStore = new ImportPreparationCacheStore(stateRoot);
+    const preparingPath = cacheStore.getImportPreparationCheckoutPath("preparing");
+    const readyPath = cacheStore.getImportPreparationCheckoutPath("ready");
+    await Promise.all([
+      fs.mkdir(preparingPath, { recursive: true }),
+      fs.mkdir(readyPath, { recursive: true }),
+    ]);
+    const base = {
+      cacheKey: "owner/repo",
+      locator: "owner/repo",
+      canonicalRepo: "owner/repo",
+      sourceKind: "git" as const,
+      sourceId: "repo",
+      displayName: "repo",
+      preparedAt: "2026-08-22T00:00:00.000Z",
+      expiresAt: "2099-08-22T00:00:00.000Z",
+      skillIds: [],
+      availableTargets: [],
+    };
+    await cacheStore.writeImportPreparationRecord({
+      ...base,
+      id: "preparing",
+      checkoutPath: preparingPath,
+      status: "preparing",
+    });
+    await cacheStore.writeImportPreparationRecord({
+      ...base,
+      id: "ready",
+      checkoutPath: readyPath,
+      status: "ready",
+    });
+
+    const recovered = await new OperationRecoveryService({ stateStore, cacheStore }).recover();
+
+    expect(recovered.ok).toBe(true);
+    await expect(fs.access(preparingPath)).rejects.toThrow();
+    await expect(fs.access(readyPath)).resolves.toBeUndefined();
+    const cache = await cacheStore.readImportPreparationCache();
+    expect(cache.records.preparing).toBeUndefined();
+    expect(cache.records.ready?.status).toBe("ready");
+  });
+
+  test("restores a ready preparation when final import commit is interrupted", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const cacheStore = new ImportPreparationCacheStore(stateRoot);
+    const preparedPath = cacheStore.getImportPreparationCheckoutPath("ready");
+    const canonicalPath = path.join(stateRoot, "source", "git", "repo");
+    await fs.mkdir(preparedPath, { recursive: true });
+    await fs.writeFile(path.join(preparedPath, "SKILL.md"), "prepared\n", "utf8");
+    await cacheStore.writeImportPreparationRecord({
+      id: "ready",
+      cacheKey: "owner/repo",
+      locator: "owner/repo",
+      canonicalRepo: "owner/repo",
+      sourceKind: "git",
+      checkoutPath: preparedPath,
+      sourceId: "repo",
+      displayName: "repo",
+      status: "ready",
+      preparedAt: "2026-08-22T00:00:00.000Z",
+      expiresAt: "2099-08-22T00:00:00.000Z",
+      skillIds: [],
+      availableTargets: [],
+    });
+    const recovery = new OperationRecoveryService({ stateStore, cacheStore });
+    await recovery.begin({
+      kind: "import",
+      sourceId: "repo",
+      checkoutPath: canonicalPath,
+      preparationId: "ready",
+    });
+    await fs.mkdir(path.dirname(canonicalPath), { recursive: true });
+    await fs.rename(preparedPath, canonicalPath);
+    await cacheStore.deleteImportPreparationRecord("ready");
+
+    const recovered = await recovery.recover();
+
+    expect(recovered.ok).toBe(true);
+    await expect(fs.access(canonicalPath)).rejects.toThrow();
+    expect(await fs.readFile(path.join(preparedPath, "SKILL.md"), "utf8")).toBe("prepared\n");
+    expect((await cacheStore.readImportPreparationCache()).records.ready?.status).toBe("ready");
+  });
+
+  test("reports an invalid recovery journal without attempting recovery", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const journalPath = path.join(stateRoot, "recovery", "active.json");
+    await fs.mkdir(path.dirname(journalPath), { recursive: true });
+    await fs.writeFile(journalPath, JSON.stringify({
+      schemaVersion: 1,
+      transactionId: "../..",
+      kind: "update",
+      sourceId: "repo",
+      phase: "prepared",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      authorityBefore: {},
+      targets: [],
+    }), "utf8");
+
+    const recovered = await new OperationRecoveryService({ stateStore }).recover();
+
+    expect(recovered.ok).toBe(false);
+    if (recovered.ok) return;
+    expect(recovered.errors[0]?.code).toBe("RECOVERY_JOURNAL_INVALID");
+  });
+});

--- a/packages/core-engine/src/tests/operation-recovery-service.test.ts
+++ b/packages/core-engine/src/tests/operation-recovery-service.test.ts
@@ -76,6 +76,98 @@ describe.sequential("OperationRecoveryService", () => {
     await expect(fs.access(path.join(stateRoot, "recovery", "active.json"))).rejects.toThrow();
   });
 
+  test("fails safely when an existing checkout backup is missing", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const checkoutPath = path.join(stateRoot, "source", "git", "repo");
+    await fs.mkdir(checkoutPath, { recursive: true });
+    await fs.writeFile(path.join(checkoutPath, "version.txt"), "old\n", "utf8");
+
+    const original = await stateStore.readState();
+    original.manifest.sources.push({
+      id: "repo",
+      kind: "git",
+      locator: "https://example.test/repo.git",
+      canonicalLocator: "https://example.test/repo.git",
+      displayName: "repo",
+      enabled: true,
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+    });
+    original.lockFile.sources.repo = {
+      sourceId: "repo",
+      canonicalLocator: "https://example.test/repo.git",
+      revision: { provider: "git", commit: "old", capturedAt: "2026-08-22T00:00:00.000Z" },
+      localPath: checkoutPath,
+      leafIds: [],
+    };
+    await stateStore.writeState(original);
+
+    const recovery = new OperationRecoveryService({ stateStore });
+    await recovery.begin({ kind: "update", sourceId: "repo", sourceKind: "git" });
+    await fs.rm(checkoutPath, { recursive: true, force: true });
+    await fs.mkdir(checkoutPath, { recursive: true });
+    await fs.writeFile(path.join(checkoutPath, "version.txt"), "new\n", "utf8");
+    const changed = await stateStore.readState();
+    changed.lockFile.sources.repo!.revision = {
+      provider: "git",
+      commit: "new",
+      capturedAt: "2026-08-22T01:00:00.000Z",
+    };
+    await stateStore.writeState(changed);
+
+    const recovered = await recovery.recover();
+
+    expect(recovered.ok).toBe(false);
+    if (recovered.ok) return;
+    expect(recovered.errors[0]?.code).toBe("RECOVERY_PATH_OWNERSHIP_INVALID");
+    expect(await fs.readFile(path.join(checkoutPath, "version.txt"), "utf8")).toBe("new\n");
+    expect((await stateStore.readState()).lockFile.sources.repo?.revision).toEqual(
+      expect.objectContaining({ commit: "new" }),
+    );
+    await expect(fs.access(path.join(stateRoot, "recovery", "active.json"))).resolves.toBeUndefined();
+  });
+
+  test("clears a pre-mutation checkout journal without requiring a backup", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const checkoutPath = path.join(stateRoot, "source", "git", "repo");
+    await fs.mkdir(checkoutPath, { recursive: true });
+    await fs.writeFile(path.join(checkoutPath, "version.txt"), "old\n", "utf8");
+
+    const original = await stateStore.readState();
+    original.manifest.sources.push({
+      id: "repo",
+      kind: "git",
+      locator: "https://example.test/repo.git",
+      canonicalLocator: "https://example.test/repo.git",
+      displayName: "repo",
+      enabled: true,
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+    });
+    original.lockFile.sources.repo = {
+      sourceId: "repo",
+      canonicalLocator: "https://example.test/repo.git",
+      revision: { provider: "git", commit: "old", capturedAt: "2026-08-22T00:00:00.000Z" },
+      localPath: checkoutPath,
+      leafIds: [],
+    };
+    await stateStore.writeState(original);
+    const recovery = new OperationRecoveryService({ stateStore });
+    await recovery.begin({ kind: "update", sourceId: "repo", sourceKind: "git" });
+
+    const recovered = await recovery.recover();
+
+    expect(recovered.ok).toBe(true);
+    expect(await fs.readFile(path.join(checkoutPath, "version.txt"), "utf8")).toBe("old\n");
+    await expect(fs.access(path.join(stateRoot, "recovery", "active.json"))).rejects.toThrow();
+  });
+
   test("does not overwrite a managed target changed after the mutation checkpoint", async () => {
     const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
     roots.push(stateRoot);
@@ -164,6 +256,50 @@ describe.sequential("OperationRecoveryService", () => {
     expect((await fs.lstat(targetPath)).isDirectory()).toBe(true);
     expect((await fs.lstat(targetPath)).isSymbolicLink()).toBe(false);
     expect(await fs.readFile(path.join(targetPath, "SKILL.md"), "utf8")).toBe("before\n");
+  });
+
+  test("fails safely when an existing target backup is missing", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const targetPath = path.join(stateRoot, "targets", "review");
+    const sourcePath = path.join(stateRoot, "source-next", "review");
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(targetPath, "before\n", "utf8");
+    await fs.writeFile(sourcePath, "by-operation\n", "utf8");
+    const recovery = new OperationRecoveryService({
+      stateStore,
+      resolveTargetRoots: async () => new Map([["codex", path.dirname(targetPath)]]),
+    });
+    await recovery.begin({ kind: "update", sourceId: "repo", sourceKind: "git" });
+    await recovery.prepareTargetMutations([{
+      kind: "update",
+      sourceId: "repo",
+      leafId: "repo:review",
+      target: "codex",
+      strategy: "copy",
+      sourcePath,
+      targetPath,
+      targetRootPath: path.dirname(targetPath),
+      contentHash: "by-operation",
+    }]);
+    const journalPath = path.join(stateRoot, "recovery", "active.json");
+    const journal = JSON.parse(await fs.readFile(journalPath, "utf8")) as {
+      transactionId: string;
+      targets: Array<{ backupName?: string }>;
+    };
+    await fs.rm(path.join(stateRoot, "recovery", journal.transactionId, journal.targets[0]!.backupName!));
+    await fs.writeFile(targetPath, "by-operation\n", "utf8");
+
+    const recovered = await recovery.recover();
+
+    expect(recovered.ok).toBe(false);
+    if (recovered.ok) return;
+    expect(recovered.errors[0]?.code).toBe("RECOVERY_PATH_OWNERSHIP_INVALID");
+    expect(await fs.readFile(targetPath, "utf8")).toBe("by-operation\n");
+    await expect(fs.access(journalPath)).resolves.toBeUndefined();
   });
 
   test("cleans interrupted preparing content while preserving ready import cache", async () => {
@@ -256,6 +392,54 @@ describe.sequential("OperationRecoveryService", () => {
     await expect(fs.access(canonicalPath)).rejects.toThrow();
     expect(await fs.readFile(path.join(preparedPath, "SKILL.md"), "utf8")).toBe("prepared\n");
     expect((await cacheStore.readImportPreparationCache()).records.ready?.status).toBe("ready");
+  });
+
+  test("does not restore a stale ready preparation when final import checkout is missing", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const cacheStore = new ImportPreparationCacheStore(stateRoot);
+    const preparedPath = cacheStore.getImportPreparationCheckoutPath("ready");
+    const canonicalPath = path.join(stateRoot, "source", "git", "repo");
+    await fs.mkdir(preparedPath, { recursive: true });
+    await fs.writeFile(path.join(preparedPath, "SKILL.md"), "prepared\n", "utf8");
+    await cacheStore.writeImportPreparationRecord({
+      id: "ready",
+      cacheKey: "owner/repo",
+      locator: "owner/repo",
+      canonicalRepo: "owner/repo",
+      sourceKind: "git",
+      checkoutPath: preparedPath,
+      sourceId: "repo",
+      displayName: "repo",
+      status: "ready",
+      preparedAt: "2026-08-22T00:00:00.000Z",
+      expiresAt: "2099-08-22T00:00:00.000Z",
+      skillIds: [],
+      availableTargets: [],
+    });
+    const recovery = new OperationRecoveryService({ stateStore, cacheStore });
+    await recovery.begin({
+      kind: "import",
+      sourceId: "repo",
+      sourceKind: "git",
+      checkoutPath: canonicalPath,
+      preparationId: "ready",
+    });
+    await fs.mkdir(path.dirname(canonicalPath), { recursive: true });
+    await fs.rename(preparedPath, canonicalPath);
+    await cacheStore.deleteImportPreparationRecord("ready");
+    await fs.rm(canonicalPath, { recursive: true, force: true });
+
+    const recovered = await recovery.recover();
+
+    expect(recovered.ok).toBe(false);
+    if (recovered.ok) return;
+    expect(recovered.errors[0]?.code).toBe("OPERATION_RECOVERY_FAILED");
+    await expect(fs.access(preparedPath)).rejects.toThrow();
+    expect((await cacheStore.readImportPreparationCache()).records.ready).toBeUndefined();
+    await expect(fs.access(path.join(stateRoot, "recovery", "active.json"))).resolves.toBeUndefined();
   });
 
   test("reports an invalid recovery journal without attempting recovery", async () => {

--- a/packages/core-engine/src/tests/operation-recovery-service.test.ts
+++ b/packages/core-engine/src/tests/operation-recovery-service.test.ts
@@ -175,6 +175,7 @@ describe.sequential("OperationRecoveryService", () => {
     await stateStore.init();
     const targetPath = path.join(stateRoot, "targets", "review");
     const sourcePath = path.join(stateRoot, "source-next", "review");
+    await seedManagedSource(stateStore);
     await fs.mkdir(path.dirname(targetPath), { recursive: true });
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });
     await fs.writeFile(targetPath, "before\n", "utf8");
@@ -227,6 +228,7 @@ describe.sequential("OperationRecoveryService", () => {
     await stateStore.init();
     const targetPath = path.join(stateRoot, "targets", "review");
     const sourcePath = path.join(stateRoot, "source", "git", "repo", "review");
+    await seedManagedSource(stateStore);
     await fs.mkdir(targetPath, { recursive: true });
     await fs.writeFile(path.join(targetPath, "SKILL.md"), "before\n", "utf8");
     await fs.mkdir(sourcePath, { recursive: true });
@@ -265,6 +267,7 @@ describe.sequential("OperationRecoveryService", () => {
     await stateStore.init();
     const targetPath = path.join(stateRoot, "targets", "review");
     const sourcePath = path.join(stateRoot, "source-next", "review");
+    await seedManagedSource(stateStore);
     await fs.mkdir(path.dirname(targetPath), { recursive: true });
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });
     await fs.writeFile(targetPath, "before\n", "utf8");
@@ -467,6 +470,62 @@ describe.sequential("OperationRecoveryService", () => {
     expect(recovered.errors[0]?.code).toBe("RECOVERY_JOURNAL_INVALID");
   });
 
+  test("rejects update recovery without matching authority source and lock", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const authorityBefore = await stateStore.readState();
+    const journalPath = path.join(stateRoot, "recovery", "active.json");
+    await fs.mkdir(path.dirname(journalPath), { recursive: true });
+    await fs.writeFile(journalPath, JSON.stringify({
+      schemaVersion: 1,
+      transactionId: "recovery-123-12345678-1234-4123-8123-123456789abc",
+      kind: "update",
+      sourceId: "repo",
+      sourceKind: "git",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      phase: "prepared",
+      authorityBefore,
+      targets: [],
+    }), "utf8");
+
+    const recovered = await new OperationRecoveryService({ stateStore }).recover();
+
+    expect(recovered.ok).toBe(false);
+    if (recovered.ok) return;
+    expect(recovered.errors[0]?.code).toBe("RECOVERY_PATH_OWNERSHIP_INVALID");
+    await expect(fs.access(journalPath)).resolves.toBeUndefined();
+  });
+
+  test("rejects import recovery without prior preparation evidence", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const authorityBefore = await stateStore.readState();
+    const journalPath = path.join(stateRoot, "recovery", "active.json");
+    await fs.mkdir(path.dirname(journalPath), { recursive: true });
+    await fs.writeFile(journalPath, JSON.stringify({
+      schemaVersion: 1,
+      transactionId: "recovery-123-12345678-1234-4123-8123-123456789abc",
+      kind: "import",
+      sourceId: "repo",
+      sourceKind: "git",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      phase: "prepared",
+      authorityBefore,
+      targets: [],
+    }), "utf8");
+
+    const recovered = await new OperationRecoveryService({ stateStore }).recover();
+
+    expect(recovered.ok).toBe(false);
+    if (recovered.ok) return;
+    expect(recovered.errors[0]?.code).toBe("RECOVERY_PATH_OWNERSHIP_INVALID");
+    await expect(fs.access(journalPath)).resolves.toBeUndefined();
+  });
+
   test("rejects a journal target outside its re-detected target root before touching the path", async () => {
     const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
     roots.push(stateRoot);
@@ -476,6 +535,7 @@ describe.sequential("OperationRecoveryService", () => {
     const legitimateTarget = path.join(targetRoot, "review");
     const sourcePath = path.join(stateRoot, "source-next", "review");
     const outsidePath = path.join(stateRoot, "outside", "keep.txt");
+    await seedManagedSource(stateStore);
     await fs.mkdir(path.dirname(legitimateTarget), { recursive: true });
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });
     await fs.mkdir(path.dirname(outsidePath), { recursive: true });
@@ -578,3 +638,37 @@ describe.sequential("OperationRecoveryService", () => {
     await expect(fs.access(journalPath)).resolves.toBeUndefined();
   });
 });
+
+async function seedManagedSource(
+  stateStore: StateStore,
+  sourceId = "repo",
+  checkoutPath = path.join(stateStore.rootPath, "source", "git", sourceId),
+): Promise<void> {
+  const state = await stateStore.readState();
+  if (!state.manifest.sources.some((source) => source.id === sourceId)) {
+    state.manifest.sources.push({
+      id: sourceId,
+      kind: "git",
+      locator: `https://example.test/${sourceId}.git`,
+      canonicalLocator: `https://example.test/${sourceId}.git`,
+      displayName: sourceId,
+      enabled: true,
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+    });
+  }
+  state.manifest.bindings[sourceId] = {
+    sourceId,
+    selectionMode: "selected",
+    selectedLeafIds: [],
+    enabledTargets: [],
+  };
+  state.lockFile.sources[sourceId] = {
+    sourceId,
+    canonicalLocator: `https://example.test/${sourceId}.git`,
+    revision: { provider: "git", commit: "old", capturedAt: "2026-08-22T00:00:00.000Z" },
+    localPath: checkoutPath,
+    leafIds: [],
+  };
+  await stateStore.writeState(state);
+}

--- a/packages/core-engine/src/tests/operation-recovery-service.test.ts
+++ b/packages/core-engine/src/tests/operation-recovery-service.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import crypto from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -49,7 +50,7 @@ describe.sequential("OperationRecoveryService", () => {
     await stateStore.writeState(original);
 
     const recovery = new OperationRecoveryService({ stateStore });
-    const transaction = await recovery.begin({ kind: "update", sourceId: "repo" });
+    const transaction = await recovery.begin({ kind: "update", sourceId: "repo", sourceKind: "git" });
     expect(transaction.checkoutBackupPath).toBeDefined();
     await fs.mkdir(path.dirname(transaction.checkoutBackupPath!), { recursive: true });
     await fs.rename(checkoutPath, transaction.checkoutBackupPath!);
@@ -99,8 +100,11 @@ describe.sequential("OperationRecoveryService", () => {
       updatedAt: "2026-08-22T00:00:00.000Z",
     });
     await stateStore.writeState(state);
-    const recovery = new OperationRecoveryService({ stateStore });
-    await recovery.begin({ kind: "update", sourceId: "repo" });
+    const recovery = new OperationRecoveryService({
+      stateStore,
+      resolveTargetRoots: async () => new Map([["codex", path.dirname(targetPath)]]),
+    });
+    await recovery.begin({ kind: "update", sourceId: "repo", sourceKind: "git" });
     await recovery.prepareTargetMutations([{
       kind: "update",
       sourceId: "repo",
@@ -135,8 +139,11 @@ describe.sequential("OperationRecoveryService", () => {
     await fs.writeFile(path.join(targetPath, "SKILL.md"), "before\n", "utf8");
     await fs.mkdir(sourcePath, { recursive: true });
     await fs.writeFile(path.join(sourcePath, "SKILL.md"), "after\n", "utf8");
-    const recovery = new OperationRecoveryService({ stateStore });
-    await recovery.begin({ kind: "update", sourceId: "repo" });
+    const recovery = new OperationRecoveryService({
+      stateStore,
+      resolveTargetRoots: async () => new Map([["codex", path.dirname(targetPath)]]),
+    });
+    await recovery.begin({ kind: "update", sourceId: "repo", sourceKind: "git" });
     await recovery.prepareTargetMutations([{
       kind: "update",
       sourceId: "repo",
@@ -235,6 +242,7 @@ describe.sequential("OperationRecoveryService", () => {
     await recovery.begin({
       kind: "import",
       sourceId: "repo",
+      sourceKind: "git",
       checkoutPath: canonicalPath,
       preparationId: "ready",
     });
@@ -273,5 +281,116 @@ describe.sequential("OperationRecoveryService", () => {
     expect(recovered.ok).toBe(false);
     if (recovered.ok) return;
     expect(recovered.errors[0]?.code).toBe("RECOVERY_JOURNAL_INVALID");
+  });
+
+  test("rejects a journal target outside its re-detected target root before touching the path", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const targetRoot = path.join(stateRoot, "targets", "codex");
+    const legitimateTarget = path.join(targetRoot, "review");
+    const sourcePath = path.join(stateRoot, "source-next", "review");
+    const outsidePath = path.join(stateRoot, "outside", "keep.txt");
+    await fs.mkdir(path.dirname(legitimateTarget), { recursive: true });
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.mkdir(path.dirname(outsidePath), { recursive: true });
+    await fs.writeFile(sourcePath, "next\n", "utf8");
+    await fs.writeFile(outsidePath, "keep\n", "utf8");
+    const recovery = new OperationRecoveryService({
+      stateStore,
+      resolveTargetRoots: async () => new Map([["codex", targetRoot]]),
+    });
+    await recovery.begin({ kind: "update", sourceId: "repo", sourceKind: "git" });
+    await recovery.prepareTargetMutations([{
+      kind: "create",
+      sourceId: "repo",
+      leafId: "repo:review",
+      target: "codex",
+      strategy: "copy",
+      sourcePath,
+      targetPath: legitimateTarget,
+      targetRootPath: targetRoot,
+      contentHash: "next",
+    }]);
+    const journalPath = path.join(stateRoot, "recovery", "active.json");
+    const journal = JSON.parse(await fs.readFile(journalPath, "utf8")) as {
+      targets: Array<Record<string, unknown>>;
+    };
+    const outsideFingerprint = crypto.createHash("sha256")
+      .update("file\0")
+      .update("keep\n")
+      .digest("hex");
+    journal.targets[0] = {
+      ...journal.targets[0],
+      path: outsidePath,
+      existed: true,
+      beforeFingerprint: outsideFingerprint,
+      mutationFingerprint: outsideFingerprint,
+    };
+    await fs.writeFile(journalPath, `${JSON.stringify(journal, null, 2)}\n`, "utf8");
+
+    const recovered = await recovery.recover();
+
+    expect(recovered.ok).toBe(false);
+    if (recovered.ok) return;
+    expect(recovered.errors[0]?.code).toBe("RECOVERY_PATH_OWNERSHIP_INVALID");
+    expect(await fs.readFile(outsidePath, "utf8")).toBe("keep\n");
+    await expect(fs.access(journalPath)).resolves.toBeUndefined();
+  });
+
+  test("rejects a tampered import preparation path before moving the managed checkout", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-"));
+    roots.push(stateRoot);
+    const stateStore = new StateStore(stateRoot);
+    await stateStore.init();
+    const cacheStore = new ImportPreparationCacheStore(stateRoot);
+    const preparedPath = cacheStore.getImportPreparationCheckoutPath("ready");
+    const canonicalPath = path.join(stateRoot, "source", "git", "repo");
+    const outsidePath = path.join(stateRoot, "outside", "keep");
+    await fs.mkdir(preparedPath, { recursive: true });
+    await fs.writeFile(path.join(preparedPath, "SKILL.md"), "prepared\n", "utf8");
+    await fs.mkdir(outsidePath, { recursive: true });
+    await fs.writeFile(path.join(outsidePath, "sentinel.txt"), "keep\n", "utf8");
+    await cacheStore.writeImportPreparationRecord({
+      id: "ready",
+      cacheKey: "owner/repo",
+      locator: "owner/repo",
+      canonicalRepo: "owner/repo",
+      sourceKind: "git",
+      checkoutPath: preparedPath,
+      sourceId: "repo",
+      displayName: "repo",
+      status: "ready",
+      preparedAt: "2026-08-22T00:00:00.000Z",
+      expiresAt: "2099-08-22T00:00:00.000Z",
+      skillIds: [],
+      availableTargets: [],
+    });
+    const recovery = new OperationRecoveryService({ stateStore, cacheStore });
+    await recovery.begin({
+      kind: "import",
+      sourceId: "repo",
+      sourceKind: "git",
+      checkoutPath: canonicalPath,
+      preparationId: "ready",
+    });
+    await fs.mkdir(path.dirname(canonicalPath), { recursive: true });
+    await fs.rename(preparedPath, canonicalPath);
+    const journalPath = path.join(stateRoot, "recovery", "active.json");
+    const journal = JSON.parse(await fs.readFile(journalPath, "utf8")) as {
+      importPreparationBefore: { checkoutPath: string };
+    };
+    journal.importPreparationBefore.checkoutPath = outsidePath;
+    await fs.writeFile(journalPath, `${JSON.stringify(journal, null, 2)}\n`, "utf8");
+
+    const recovered = await recovery.recover();
+
+    expect(recovered.ok).toBe(false);
+    if (recovered.ok) return;
+    expect(recovered.errors[0]?.code).toBe("RECOVERY_PATH_OWNERSHIP_INVALID");
+    await expect(fs.access(canonicalPath)).resolves.toBeUndefined();
+    expect(await fs.readFile(path.join(outsidePath, "sentinel.txt"), "utf8")).toBe("keep\n");
+    await expect(fs.access(journalPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/core-engine/src/tests/operation-recovery-service.test.ts
+++ b/packages/core-engine/src/tests/operation-recovery-service.test.ts
@@ -487,6 +487,7 @@ describe.sequential("OperationRecoveryService", () => {
       startedAt: "2026-08-22T00:00:00.000Z",
       phase: "prepared",
       authorityBefore,
+      checkout: recoveryCheckoutSnapshot(stateRoot),
       targets: [],
     }), "utf8");
 
@@ -515,6 +516,7 @@ describe.sequential("OperationRecoveryService", () => {
       startedAt: "2026-08-22T00:00:00.000Z",
       phase: "prepared",
       authorityBefore,
+      checkout: recoveryCheckoutSnapshot(stateRoot),
       targets: [],
     }), "utf8");
 
@@ -522,7 +524,7 @@ describe.sequential("OperationRecoveryService", () => {
 
     expect(recovered.ok).toBe(false);
     if (recovered.ok) return;
-    expect(recovered.errors[0]?.code).toBe("RECOVERY_PATH_OWNERSHIP_INVALID");
+    expect(recovered.errors[0]?.code).toBe("RECOVERY_JOURNAL_INVALID");
     await expect(fs.access(journalPath)).resolves.toBeUndefined();
   });
 
@@ -671,4 +673,16 @@ async function seedManagedSource(
     leafIds: [],
   };
   await stateStore.writeState(state);
+}
+
+function recoveryCheckoutSnapshot(stateRoot: string): Record<string, unknown> {
+  return {
+    role: "checkout",
+    sourceId: "repo",
+    sourceKind: "git",
+    path: path.join(stateRoot, "source", "git", "repo"),
+    existed: true,
+    backupName: "checkout",
+    beforeFingerprint: "before",
+  };
 }

--- a/packages/query/src/config-coordinator.ts
+++ b/packages/query/src/config-coordinator.ts
@@ -44,6 +44,7 @@ type ConfigCoordinatorDeps = {
     ): WorkflowSummary[];
   };
   getAvailableTargets(): Promise<DeploymentTargetId[]>;
+  recoverInterruptedOperation?(): Promise<Result<{ recovered: boolean }>>;
   pruneMissingCheckouts(): Promise<Result<{ removedSourceIds: string[] }>>;
   ensureBuiltInSources?(): Promise<Result<{ sourceIds: string[] }>>;
   getConfigData(): Promise<
@@ -70,6 +71,10 @@ export class ConfigCoordinator {
   async bootstrapWorkspaceState(
     onEvent?: (event: BootstrapEvent) => void,
   ): Promise<Result<ConfigBootstrapData>> {
+    const recovery = await this.deps.recoverInterruptedOperation?.();
+    if (recovery && !recovery.ok) {
+      return fail(recovery.errors, recovery.warnings);
+    }
     onEvent?.({
       phase: "detect-targets",
       level: "info",
@@ -81,7 +86,7 @@ export class ConfigCoordinator {
     if (!pruned.ok) {
       return fail(pruned.errors, pruned.warnings);
     }
-    const warnings: Warning[] = [...pruned.warnings];
+    const warnings: Warning[] = [...(recovery?.warnings ?? []), ...pruned.warnings];
     if (pruned.data.removedSourceIds.length > 0) {
       onEvent?.({
         phase: "refresh-sources",

--- a/packages/query/src/runtime.ts
+++ b/packages/query/src/runtime.ts
@@ -130,6 +130,7 @@ import {
   type ExternalSourceSnapshot,
 } from "@skill-flow/core-engine/services/external-source-lifecycle";
 import { InventoryService } from "@skill-flow/core-engine/services/inventory-service";
+import { OperationRecoveryService } from "@skill-flow/core-engine/services/operation-recovery-service";
 import { ImportPreparationService } from "@skill-flow/core-engine/services/import-preparation-service";
 import { RecentProjectService } from "@skill-flow/core-engine/services/recent-project-service";
 import { SourceAuthorityService } from "@skill-flow/core-engine/services/source-authority-service";
@@ -451,6 +452,7 @@ export class SkillFlowApp {
   readonly sourceAuthorityService: SourceAuthorityService;
   readonly externalSourceLifecycle: ExternalSourceLifecycle;
   readonly importPreparationService: ImportPreparationService;
+  readonly operationRecoveryService: OperationRecoveryService;
   readonly doctorService: DoctorService;
   readonly workflowService: WorkflowService;
   readonly recentProjectService: RecentProjectService;
@@ -489,6 +491,10 @@ export class SkillFlowApp {
       sourceAuthority: this.sourceAuthorityService,
       checkoutService: this.sourceCheckoutService,
     });
+    this.operationRecoveryService = new OperationRecoveryService({
+      stateStore: this.stateStore,
+      cacheStore: this.importPreparationCacheStore,
+    });
     this.doctorService = new DoctorService();
     this.workflowService = new WorkflowService();
     this.recentProjectService = new RecentProjectService();
@@ -508,6 +514,7 @@ export class SkillFlowApp {
       doctorService: this.doctorService,
       workflowService: this.workflowService,
       getAvailableTargets: () => this.getAvailableTargets(),
+      recoverInterruptedOperation: () => this.operationRecoveryService.recover(),
       pruneMissingCheckouts: () => this.pruneMissingCheckoutsImpl(),
       ensureBuiltInSources: () => this.ensureBuiltInSourcesImpl(),
       getConfigData: async () => {
@@ -2820,11 +2827,31 @@ export class SkillFlowApp {
     canonicalRepo?: string,
     localSkillPath?: string,
   ): Promise<Result<ImportSourceResult>> {
+    const preparation = (await this.importPreparationCacheStore.readImportPreparationCache())
+      .records[preparationId];
+    if (!preparation || preparation.status !== "ready") {
+      return this.importPreparationService.commitPreparedImportSource(preparationId);
+    }
+    const canonicalCheckoutPath = path.join(
+      this.stateStore.rootPath,
+      "source",
+      preparation.sourceKind,
+      preparation.sourceId,
+    );
+    await this.operationRecoveryService.begin({
+      kind: "import",
+      sourceId: preparation.sourceId,
+      checkoutPath: canonicalCheckoutPath,
+      preparationId,
+    });
     const committed = await this.importPreparationService.commitPreparedImportSource(preparationId);
     if (!committed.ok) {
+      const recovered = await this.operationRecoveryService.recover();
+      if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
       return committed;
     }
     if (committed.data.status !== "ready") {
+      await this.operationRecoveryService.commit();
       return ok(committed.data, committed.warnings);
     }
     const committedData = committed.data;
@@ -2839,7 +2866,8 @@ export class SkillFlowApp {
       draft,
     );
     if (!finalDraft.ok) {
-      await this.rollbackPreparedSourceInternal(committedData.sourceId);
+      const recovered = await this.operationRecoveryService.recover();
+      if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
       return ok({
         status: "failed",
         reasonCode: finalDraft.errors[0]?.code ?? "IMPORT_PREVIEW_INVALID",
@@ -2847,9 +2875,15 @@ export class SkillFlowApp {
       }, [...committed.warnings, ...finalDraft.warnings]);
     }
 
-    const applied = await this.applyDraftImpl(committedData.sourceId, finalDraft.data, { kind: "global" });
+    const applied = await this.applyDraftImpl(
+      committedData.sourceId,
+      finalDraft.data,
+      { kind: "global" },
+      { recoverable: true },
+    );
     if (!applied.ok) {
-      await this.rollbackPreparedSourceInternal(committedData.sourceId);
+      const recovered = await this.operationRecoveryService.recover();
+      if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
       return ok({
         status: "failed",
         reasonCode: applied.errors[0]?.code ?? "IMPORT_APPLY_FAILED",
@@ -2857,7 +2891,13 @@ export class SkillFlowApp {
       }, [...committed.warnings, ...finalDraft.warnings, ...applied.warnings]);
     }
 
-    await this.replaceLocalImportWithManagedSymlink(localSkillPath, committedData.sourceId);
+    await this.replaceLocalImportWithManagedSymlink(
+      localSkillPath,
+      committedData.sourceId,
+      { recoverable: true },
+    );
+    await this.operationRecoveryService.checkpoint();
+    await this.operationRecoveryService.commit();
 
     return ok(committedData, [...committed.warnings, ...finalDraft.warnings, ...applied.warnings]);
   }
@@ -3041,6 +3081,7 @@ export class SkillFlowApp {
   private async replaceLocalImportWithManagedSymlink(
     localSkillPath: string | undefined,
     sourceId: string,
+    options: { recoverable?: boolean } = {},
   ): Promise<void> {
     if (!localSkillPath) {
       return;
@@ -3052,6 +3093,12 @@ export class SkillFlowApp {
     const { lockFile } = await this.readRuntimeAuthorityView();
     const source = lockFile.sources[sourceId];
     if (source?.localPath) {
+      if (options.recoverable) {
+        await this.operationRecoveryService.prepareManagedSymlinkMutation(
+          localSkillPath,
+          source.localPath,
+        );
+      }
       await createSymlink(source.localPath, localSkillPath);
     }
   }
@@ -4715,6 +4762,7 @@ export class SkillFlowApp {
     sourceId: string,
     draft: DraftBinding,
     scope: ProjectScope,
+    options: { recoverable?: boolean } = {},
   ): Promise<Result<ApplyDraftResult>> {
     if (scope.kind === "project") {
       const runtimeView = await this.readRuntimeAuthorityView();
@@ -4869,6 +4917,9 @@ export class SkillFlowApp {
       lockFile,
       sourceId,
       preferences,
+      options.recoverable
+        ? (actions) => this.operationRecoveryService.prepareTargetMutations(actions)
+        : undefined,
     );
     if (!reconciled.ok) {
       return fail(
@@ -5158,47 +5209,129 @@ export class SkillFlowApp {
   }
 
   private async updateSourcesImpl(sourceIds?: string[]): Promise<Result<SourceUpdateResult>> {
+    const initialState = await this.stateStore.readState();
+    const requestedIds = sourceIds?.length
+      ? [...new Set(sourceIds)]
+      : initialState.manifest.sources
+        .filter((source) => source.ownership !== "external")
+        .map((source) => source.id);
     const externalSourceIds = sourceIds?.length
       ? []
-      : (await this.stateStore.readState()).manifest.sources
+      : initialState.manifest.sources
         .filter((source) => source.ownership === "external")
         .map((source) => source.id);
-    const updated = await this.sourceAuthorityService.updateSources(sourceIds);
-    if (!updated.ok) {
-      return updated;
+    const updatedItems: SourceUpdateResultItem[] = [];
+    const failed: NonNullable<SourceUpdateResult["failed"]> = [];
+    const warnings: Warning[] = [];
+    const precheckFallbackSourceIds: string[] = [];
+    const hardErrors: Array<{ code: string; message: string }> = [];
+
+    for (const sourceId of requestedIds) {
+      const currentState = await this.stateStore.readState();
+      const source = currentState.manifest.sources.find((candidate) => candidate.id === sourceId);
+      const lock = currentState.lockFile.sources[sourceId];
+      const managed = source
+        && source.kind !== "collection"
+        && source.ownership !== "external"
+        && lock?.ownership !== "external";
+      let transaction: { checkoutBackupPath?: string } | undefined;
+      try {
+        if (managed) {
+          transaction = await this.operationRecoveryService.begin({ kind: "update", sourceId });
+        }
+        const updated = await this.sourceAuthorityService.updateSources([sourceId], {
+          ...(transaction?.checkoutBackupPath
+            ? { checkoutBackupPath: transaction.checkoutBackupPath, retainCheckoutBackup: true }
+            : {}),
+        });
+        warnings.push(...updated.warnings);
+        if (!updated.ok) {
+          hardErrors.push(...updated.errors);
+          const first = updated.errors[0] ?? {
+            code: "SOURCE_UPDATE_FAILED",
+            message: `Unable to update skills group '${sourceId}'.`,
+          };
+          failed.push({ sourceId, code: first.code, message: first.message });
+          if (transaction) {
+            const recovered = await this.operationRecoveryService.recover();
+            if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
+          }
+          continue;
+        }
+
+        precheckFallbackSourceIds.push(...(updated.data.precheckFallbackSourceIds ?? []));
+        if (!transaction) {
+          updatedItems.push(...updated.data.updated);
+          continue;
+        }
+
+        const state = await this.stateStore.readState();
+        const manifest = this.cloneAuthorityManifest(state.manifest);
+        const lockFile = this.cloneLockFile(state.lockFile);
+        const adapters = this.createAdaptersForPreferences(state.preferences);
+        const projectedSourceIds = new Set(
+          lockFile.projections
+            .filter((projection) => projection.status === "active")
+            .map((projection) => projection.sourceId),
+        );
+        const planSourceIds = manifest.sources
+          .map((candidate) => candidate.id)
+          .filter((candidateId) =>
+            candidateId === sourceId
+            || this.hasActiveTargets(manifest, candidateId)
+            || projectedSourceIds.has(candidateId),
+          );
+        const planned = await this.deploymentReconciler.plan({
+          manifest,
+          lockFile,
+          sourceIds: planSourceIds,
+          adapters,
+        });
+        warnings.push(...planned.warnings);
+        if (!planned.ok) {
+          hardErrors.push(...planned.errors);
+          const first = planned.errors[0]!;
+          failed.push({ sourceId, code: first.code, message: first.message });
+          const recovered = await this.operationRecoveryService.recover();
+          if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
+          continue;
+        }
+        await this.operationRecoveryService.prepareTargetMutations(planned.data.actions);
+        const applied = await this.deploymentReconciler.apply({
+          lockFile,
+          actions: planned.data.actions,
+          adapters,
+        });
+        warnings.push(...applied.warnings);
+        if (!applied.ok) {
+          hardErrors.push(...applied.errors);
+          const first = applied.errors[0]!;
+          failed.push({ sourceId, code: first.code, message: first.message });
+          const recovered = await this.operationRecoveryService.recover();
+          if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
+          continue;
+        }
+        await this.stateStore.writeState({ ...state, manifest, lockFile });
+        await this.operationRecoveryService.checkpoint();
+        await this.operationRecoveryService.commit();
+        updatedItems.push(...updated.data.updated);
+      } catch (error) {
+        if (transaction) {
+          const recovered = await this.operationRecoveryService.recover();
+          if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
+        }
+        const failure = {
+          code: "SOURCE_UPDATE_FAILED",
+          message: `Unable to update skills group '${sourceId}': ${String(error)}`,
+        };
+        hardErrors.push(failure);
+        failed.push({ sourceId, ...failure });
+      }
     }
 
-    const state = await this.stateStore.readState();
-    const manifest = this.cloneAuthorityManifest(state.manifest);
-    const lockFile = this.cloneLockFile(state.lockFile);
-    const preferences = state.preferences;
-    const updatedSourceIds = new Set(updated.data.updated.map((item) => item.sourceId));
-    const projectedSourceIds = new Set(
-      lockFile.projections
-        .filter((projection) => projection.status === "active")
-        .map((projection) => projection.sourceId),
-    );
-    const planSourceIds = manifest.sources
-      .map((source) => source.id)
-      .filter((id) =>
-        updatedSourceIds.has(id) ||
-        this.hasActiveTargets(manifest, id) ||
-        projectedSourceIds.has(id),
-      );
-    const reconciled = await this.deploymentReconciler.reconcile({
-      manifest,
-      lockFile,
-      sourceIds: planSourceIds,
-      adapters: this.createAdaptersForPreferences(preferences),
-    });
-    if (!reconciled.ok) {
-      return fail(reconciled.errors, [...updated.warnings, ...reconciled.warnings]);
+    if (updatedItems.length === 0 && hardErrors.length > 0) {
+      return fail(hardErrors, warnings);
     }
-    await this.stateStore.writeState({
-      ...state,
-      manifest,
-      lockFile,
-    });
     const externalWarnings: Warning[] = [];
     for (const sourceId of externalSourceIds) {
       const refreshed = await this.externalSourceLifecycle.refresh(sourceId);
@@ -5211,7 +5344,17 @@ export class SkillFlowApp {
         externalWarnings.push(...refreshed.warnings);
       }
     }
-    return ok(updated.data, [...updated.warnings, ...reconciled.warnings, ...externalWarnings]);
+    const status: SourceUpdateResult["status"] = failed.length === 0
+      ? "updated"
+      : updatedItems.length === 0
+        ? "failed"
+        : "partial";
+    return ok({
+      status,
+      updated: updatedItems,
+      ...(failed.length > 0 ? { failed } : {}),
+      ...(precheckFallbackSourceIds.length > 0 ? { precheckFallbackSourceIds } : {}),
+    }, [...warnings, ...externalWarnings]);
   }
 
   async doctor(): Promise<Result<DoctorReport>> {
@@ -6986,17 +7129,30 @@ export class SkillFlowApp {
     lockFile: LockFile,
     primarySourceId: string,
     preferences: Pick<PreferencesFile, "customTargets" | "agentDisplayOrder">,
-  ) {
+    beforeApply?: (actions: DeploymentAction[]) => Promise<void>,
+  ): Promise<Result<{ actions: DeploymentAction[] }>> {
     const sourceIds = manifest.sources
       .map((source) => source.id)
       .filter((sourceId) => sourceId === primarySourceId || this.hasActiveTargets(manifest, sourceId));
 
-    return this.deploymentReconciler.reconcile({
+    const adapters = this.createAdaptersForPreferences(preferences);
+    const planned = await this.deploymentReconciler.plan({
       manifest,
       lockFile,
       sourceIds,
-      adapters: this.createAdaptersForPreferences(preferences),
+      adapters,
     });
+    if (!planned.ok) return planned;
+    await beforeApply?.(planned.data.actions);
+    const applied = await this.deploymentReconciler.apply({
+      lockFile,
+      actions: planned.data.actions,
+      adapters,
+    });
+    if (!applied.ok) {
+      return fail(applied.errors, [...planned.warnings, ...applied.warnings]);
+    }
+    return ok({ actions: planned.data.actions }, [...planned.warnings, ...applied.warnings]);
   }
 
   private getEnabledTargetsForSource(

--- a/packages/query/src/runtime.ts
+++ b/packages/query/src/runtime.ts
@@ -80,6 +80,7 @@ import {
   pathExists,
   readJsonFile,
   removePath,
+  withFileLock,
   writeJsonFile,
 } from "@skill-flow/integration/utils/fs";
 import { getBuiltinGitSources } from "@skill-flow/integration/utils/builtin-git-sources";
@@ -137,6 +138,7 @@ import { SourceAuthorityService } from "@skill-flow/core-engine/services/source-
 import { SourceCheckoutService } from "@skill-flow/core-engine/services/source-checkout-service";
 import {
   StateMigrationService,
+  StateMigrationError,
   type StateMigrationOptions,
   type StateMigrationResult,
 } from "@skill-flow/core-engine/services/state-migration-service";
@@ -494,6 +496,16 @@ export class SkillFlowApp {
     this.operationRecoveryService = new OperationRecoveryService({
       stateStore: this.stateStore,
       cacheStore: this.importPreparationCacheStore,
+      resolveTargetRoots: async () => {
+        const { preferences } = await this.stateStore.readState();
+        const detected = await Promise.all(
+          this.createAdaptersForPreferences(preferences).map(async (adapter) => {
+            const target = await adapter.detect();
+            return [adapter.target, target.rootPath] as const;
+          }),
+        );
+        return new Map(detected);
+      },
     });
     this.doctorService = new DoctorService();
     this.workflowService = new WorkflowService();
@@ -1537,7 +1549,51 @@ export class SkillFlowApp {
 
   migrateState(options: StateMigrationOptions): Promise<StateMigrationResult> {
     return this.runSerializedTask(async () => {
-      const result = await new StateMigrationService({ stateRoot: this.store.rootPath }).migrate(options);
+      const migration = new StateMigrationService({ stateRoot: this.store.rootPath });
+      if (options.dryRun) {
+        return migration.migrate(options);
+      }
+      const result = await withFileLock(
+        path.join(this.store.rootPath, ".mutation.lock"),
+        async () => {
+          const status = await migration.inspect();
+          const hasRecoveryJournal = await pathExists(
+            path.join(this.store.rootPath, "recovery", "active.json"),
+          );
+          if (status.status === "migration-required" && hasRecoveryJournal) {
+            throw new StateMigrationError({
+              reasonCode: "RECOVERY_STATE_INCONSISTENT",
+              diagnostics: [{
+                code: "RECOVERY_STATE_INCONSISTENT",
+                message: "State migration is blocked because a recovery journal exists beside V1 authority.",
+                path: path.join(this.store.rootPath, "recovery", "active.json"),
+                retryable: false,
+              }],
+            });
+          }
+          if (status.status === "current") {
+            const recovered = await this.operationRecoveryService.recover();
+            if (!recovered.ok) {
+              throw new StateMigrationError({
+                reasonCode: recovered.errors[0]?.code ?? "OPERATION_RECOVERY_FAILED",
+                diagnostics: recovered.errors.map((error) => ({
+                  code: error.code,
+                  message: error.message,
+                  retryable: true,
+                })),
+              });
+            }
+          }
+          return migration.migrate(options);
+        },
+        {
+          metadata: {
+            command: "migrate-state",
+            pid: process.pid,
+            startedAt: new Date().toISOString(),
+          },
+        },
+      );
       if (result.status === "migrated") {
         await this.warmRebuildableCacheAfterMigration();
       }
@@ -2841,6 +2897,7 @@ export class SkillFlowApp {
     await this.operationRecoveryService.begin({
       kind: "import",
       sourceId: preparation.sourceId,
+      sourceKind: preparation.sourceKind,
       checkoutPath: canonicalCheckoutPath,
       preparationId,
     });
@@ -3086,8 +3143,8 @@ export class SkillFlowApp {
     if (!localSkillPath) {
       return;
     }
-    const isManagedByTargetRoot = await this.isLocalImportTargetPath(localSkillPath);
-    if (!isManagedByTargetRoot) {
+    const targetOwnership = await this.resolveLocalImportTargetOwnership(localSkillPath);
+    if (!targetOwnership) {
       return;
     }
     const { lockFile } = await this.readRuntimeAuthorityView();
@@ -3097,26 +3154,44 @@ export class SkillFlowApp {
         await this.operationRecoveryService.prepareManagedSymlinkMutation(
           localSkillPath,
           source.localPath,
+          { sourceId, target: targetOwnership.target },
         );
       }
       await createSymlink(source.localPath, localSkillPath);
     }
   }
 
-  private async isLocalImportTargetPath(localSkillPath: string): Promise<boolean> {
-    for (const target of TARGET_ORDER) {
-      for (const root of getTargetScanRoots(target).map((root) => path.resolve(root))) {
-        if (isPathInside(root, localSkillPath)) {
-          return true;
-        }
-        const resolvedRoot = await fs.realpath(root).catch(() => root);
-        const resolvedLocalSkillPath = await fs.realpath(localSkillPath).catch(() => localSkillPath);
-        if (isPathInside(resolvedRoot, resolvedLocalSkillPath)) {
-          return true;
-        }
+  private async resolveLocalImportTargetOwnership(
+    localSkillPath: string,
+  ): Promise<{ target: DeploymentTargetId; rootPath: string } | undefined> {
+    const { preferences } = await this.stateStore.readState();
+    const detectedRoots = await Promise.all(
+      this.createAdaptersForPreferences(preferences).map(async (adapter) => {
+        const detection = await adapter.detect();
+        return { target: adapter.target, rootPath: path.resolve(detection.rootPath) };
+      }),
+    );
+    const candidates = [
+      ...detectedRoots,
+      ...TARGET_ORDER.flatMap((target) =>
+        getTargetScanRoots(target).map((rootPath) => ({
+          target,
+          rootPath: path.resolve(rootPath),
+        })),
+      ),
+    ];
+    for (const candidate of candidates) {
+      const root = candidate.rootPath;
+      if (isPathInside(root, localSkillPath)) {
+        return candidate;
+      }
+      const resolvedRoot = await fs.realpath(root).catch(() => root);
+      const resolvedLocalSkillPath = await fs.realpath(localSkillPath).catch(() => localSkillPath);
+      if (isPathInside(resolvedRoot, resolvedLocalSkillPath)) {
+        return candidate;
       }
     }
-    return false;
+    return undefined;
   }
 
   private async resolveSourceMetadata(
@@ -5209,6 +5284,10 @@ export class SkillFlowApp {
   }
 
   private async updateSourcesImpl(sourceIds?: string[]): Promise<Result<SourceUpdateResult>> {
+    const preflight = await this.sourceAuthorityService.preflightUpdateSources(sourceIds);
+    if (!preflight.ok) {
+      return fail(preflight.errors, preflight.warnings);
+    }
     const initialState = await this.stateStore.readState();
     const requestedIds = sourceIds?.length
       ? [...new Set(sourceIds)]
@@ -5222,7 +5301,7 @@ export class SkillFlowApp {
         .map((source) => source.id);
     const updatedItems: SourceUpdateResultItem[] = [];
     const failed: NonNullable<SourceUpdateResult["failed"]> = [];
-    const warnings: Warning[] = [];
+    const warnings: Warning[] = [...preflight.warnings];
     const precheckFallbackSourceIds: string[] = [];
     const hardErrors: Array<{ code: string; message: string }> = [];
 
@@ -5237,7 +5316,11 @@ export class SkillFlowApp {
       let transaction: { checkoutBackupPath?: string } | undefined;
       try {
         if (managed) {
-          transaction = await this.operationRecoveryService.begin({ kind: "update", sourceId });
+          transaction = await this.operationRecoveryService.begin({
+            kind: "update",
+            sourceId,
+            sourceKind: source.kind,
+          });
         }
         const updated = await this.sourceAuthorityService.updateSources([sourceId], {
           ...(transaction?.checkoutBackupPath

--- a/packages/query/src/runtime.ts
+++ b/packages/query/src/runtime.ts
@@ -2903,9 +2903,7 @@ export class SkillFlowApp {
     });
     const committed = await this.importPreparationService.commitPreparedImportSource(preparationId);
     if (!committed.ok) {
-      const recovered = await this.operationRecoveryService.recover();
-      if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
-      return committed;
+      return this.recoverInterruptedOperationOrReturn(committed);
     }
     if (committed.data.status !== "ready") {
       await this.operationRecoveryService.commit();
@@ -2923,13 +2921,11 @@ export class SkillFlowApp {
       draft,
     );
     if (!finalDraft.ok) {
-      const recovered = await this.operationRecoveryService.recover();
-      if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
-      return ok({
+      return this.recoverInterruptedOperationOrReturn(ok({
         status: "failed",
         reasonCode: finalDraft.errors[0]?.code ?? "IMPORT_PREVIEW_INVALID",
         retryable: true,
-      }, [...committed.warnings, ...finalDraft.warnings]);
+      }, [...committed.warnings, ...finalDraft.warnings]));
     }
 
     const applied = await this.applyDraftImpl(
@@ -2939,13 +2935,11 @@ export class SkillFlowApp {
       { recoverable: true },
     );
     if (!applied.ok) {
-      const recovered = await this.operationRecoveryService.recover();
-      if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
-      return ok({
+      return this.recoverInterruptedOperationOrReturn(ok({
         status: "failed",
         reasonCode: applied.errors[0]?.code ?? "IMPORT_APPLY_FAILED",
         retryable: true,
-      }, [...committed.warnings, ...finalDraft.warnings, ...applied.warnings]);
+      }, [...committed.warnings, ...finalDraft.warnings, ...applied.warnings]));
     }
 
     await this.replaceLocalImportWithManagedSymlink(
@@ -5336,7 +5330,7 @@ export class SkillFlowApp {
           };
           failed.push({ sourceId, code: first.code, message: first.message });
           if (transaction) {
-            const recovered = await this.operationRecoveryService.recover();
+            const recovered = await this.recoverInterruptedOperation();
             if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
           }
           continue;
@@ -5375,7 +5369,7 @@ export class SkillFlowApp {
           hardErrors.push(...planned.errors);
           const first = planned.errors[0]!;
           failed.push({ sourceId, code: first.code, message: first.message });
-          const recovered = await this.operationRecoveryService.recover();
+          const recovered = await this.recoverInterruptedOperation();
           if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
           continue;
         }
@@ -5390,7 +5384,7 @@ export class SkillFlowApp {
           hardErrors.push(...applied.errors);
           const first = applied.errors[0]!;
           failed.push({ sourceId, code: first.code, message: first.message });
-          const recovered = await this.operationRecoveryService.recover();
+          const recovered = await this.recoverInterruptedOperation();
           if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
           continue;
         }
@@ -5400,7 +5394,7 @@ export class SkillFlowApp {
         updatedItems.push(...updated.data.updated);
       } catch (error) {
         if (transaction) {
-          const recovered = await this.operationRecoveryService.recover();
+          const recovered = await this.recoverInterruptedOperation();
           if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
         }
         const failure = {
@@ -6423,6 +6417,22 @@ export class SkillFlowApp {
 
   private async runSerializedMutation<T>(task: () => Promise<T>): Promise<T> {
     return this.runSerializedTask(() => this.stateStore.withMutationLock(task));
+  }
+
+  private async recoverInterruptedOperation(): Promise<Result<void>> {
+    const recovered = await this.operationRecoveryService.recover();
+    return recovered.ok
+      ? ok(undefined, recovered.warnings)
+      : fail(recovered.errors, recovered.warnings);
+  }
+
+  private async recoverInterruptedOperationOrReturn<T>(
+    fallback: Result<T>,
+  ): Promise<Result<T>> {
+    const recovered = await this.operationRecoveryService.recover();
+    return recovered.ok
+      ? fallback
+      : fail(recovered.errors, recovered.warnings);
   }
 
   private async runSerializedTask<T>(task: () => Promise<T>): Promise<T> {

--- a/packages/query/src/runtime.ts
+++ b/packages/query/src/runtime.ts
@@ -5298,16 +5298,32 @@ export class SkillFlowApp {
     const warnings: Warning[] = [...preflight.warnings];
     const precheckFallbackSourceIds: string[] = [];
     const hardErrors: Array<{ code: string; message: string }> = [];
+    const recordFailureAndRecover = async (
+      sourceId: string,
+      failureErrors: Array<{ code: string; message: string }>,
+      fallback: { code: string; message: string },
+      shouldRecover: boolean,
+    ): Promise<Result<void>> => {
+      const primary = failureErrors[0] ?? fallback;
+      hardErrors.push(...(failureErrors.length > 0 ? failureErrors : [fallback]));
+      failed.push({ sourceId, code: primary.code, message: primary.message });
+      if (!shouldRecover) return ok(undefined);
+      const recovered = await this.recoverInterruptedOperation();
+      if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
+      warnings.push(...recovered.warnings);
+      return ok(undefined);
+    };
 
     for (const sourceId of requestedIds) {
       const currentState = await this.stateStore.readState();
       const source = currentState.manifest.sources.find((candidate) => candidate.id === sourceId);
       const lock = currentState.lockFile.sources[sourceId];
       const managed = source
+        && lock
         && source.kind !== "collection"
         && source.ownership !== "external"
-        && lock?.ownership !== "external";
-      let transaction: { checkoutBackupPath?: string } | undefined;
+        && lock.ownership !== "external";
+      let transaction: { checkoutBackupPath: string } | undefined;
       try {
         if (managed) {
           transaction = await this.operationRecoveryService.begin({
@@ -5317,22 +5333,17 @@ export class SkillFlowApp {
           });
         }
         const updated = await this.sourceAuthorityService.updateSources([sourceId], {
-          ...(transaction?.checkoutBackupPath
+          ...(transaction
             ? { checkoutBackupPath: transaction.checkoutBackupPath, retainCheckoutBackup: true }
             : {}),
         });
         warnings.push(...updated.warnings);
         if (!updated.ok) {
-          hardErrors.push(...updated.errors);
-          const first = updated.errors[0] ?? {
+          const handled = await recordFailureAndRecover(sourceId, updated.errors, {
             code: "SOURCE_UPDATE_FAILED",
             message: `Unable to update skills group '${sourceId}'.`,
-          };
-          failed.push({ sourceId, code: first.code, message: first.message });
-          if (transaction) {
-            const recovered = await this.recoverInterruptedOperation();
-            if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
-          }
+          }, transaction !== undefined);
+          if (!handled.ok) return fail(handled.errors, handled.warnings);
           continue;
         }
 
@@ -5366,11 +5377,11 @@ export class SkillFlowApp {
         });
         warnings.push(...planned.warnings);
         if (!planned.ok) {
-          hardErrors.push(...planned.errors);
-          const first = planned.errors[0]!;
-          failed.push({ sourceId, code: first.code, message: first.message });
-          const recovered = await this.recoverInterruptedOperation();
-          if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
+          const handled = await recordFailureAndRecover(sourceId, planned.errors, {
+            code: "DEPLOYMENT_PLAN_FAILED",
+            message: `Unable to plan deployment for '${sourceId}'.`,
+          }, true);
+          if (!handled.ok) return fail(handled.errors, handled.warnings);
           continue;
         }
         await this.operationRecoveryService.prepareTargetMutations(planned.data.actions);
@@ -5381,11 +5392,11 @@ export class SkillFlowApp {
         });
         warnings.push(...applied.warnings);
         if (!applied.ok) {
-          hardErrors.push(...applied.errors);
-          const first = applied.errors[0]!;
-          failed.push({ sourceId, code: first.code, message: first.message });
-          const recovered = await this.recoverInterruptedOperation();
-          if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
+          const handled = await recordFailureAndRecover(sourceId, applied.errors, {
+            code: "DEPLOYMENT_APPLY_FAILED",
+            message: `Unable to apply deployment for '${sourceId}'.`,
+          }, true);
+          if (!handled.ok) return fail(handled.errors, handled.warnings);
           continue;
         }
         await this.stateStore.writeState({ ...state, manifest, lockFile });
@@ -5393,16 +5404,12 @@ export class SkillFlowApp {
         await this.operationRecoveryService.commit();
         updatedItems.push(...updated.data.updated);
       } catch (error) {
-        if (transaction) {
-          const recovered = await this.recoverInterruptedOperation();
-          if (!recovered.ok) return fail(recovered.errors, recovered.warnings);
-        }
         const failure = {
           code: "SOURCE_UPDATE_FAILED",
           message: `Unable to update skills group '${sourceId}': ${String(error)}`,
         };
-        hardErrors.push(failure);
-        failed.push({ sourceId, ...failure });
+        const handled = await recordFailureAndRecover(sourceId, [failure], failure, transaction !== undefined);
+        if (!handled.ok) return fail(handled.errors, handled.warnings);
       }
     }
 

--- a/packages/query/src/tests/config-coordinator.test.ts
+++ b/packages/query/src/tests/config-coordinator.test.ts
@@ -424,6 +424,10 @@ describe("ConfigCoordinator", () => {
         getSummaries: vi.fn().mockReturnValue(summaries),
       },
       getAvailableTargets: vi.fn().mockResolvedValue(["codex"]),
+      recoverInterruptedOperation: vi.fn().mockImplementation(async () => {
+        calls.push("recover");
+        return { ok: true, data: { recovered: true }, warnings: [], errors: [] };
+      }),
       pruneMissingCheckouts: vi.fn().mockImplementation(async () => {
         calls.push("prune");
         return {
@@ -456,7 +460,7 @@ describe("ConfigCoordinator", () => {
     const result = await coordinator.bootstrapWorkspaceState();
 
     expect(result.ok).toBe(true);
-    expect(calls).toEqual(["prune", "ensure-built-in", "config-data"]);
+    expect(calls).toEqual(["recover", "prune", "ensure-built-in", "config-data"]);
   });
 
   test("restores selected skills from binding even when enabled targets are empty", async () => {

--- a/packages/query/src/tests/runtime-source-v2.test.ts
+++ b/packages/query/src/tests/runtime-source-v2.test.ts
@@ -188,6 +188,7 @@ describe.sequential("runtime source v2 write chain", () => {
         status: "active",
       }),
     ]);
+    await expect(fs.access(path.join(sandbox.stateRoot, "recovery", "active.json"))).rejects.toThrow();
   });
 
   test("importSource rolls back the v2 source when requested targets are invalid", async () => {
@@ -333,6 +334,7 @@ describe.sequential("runtime source v2 write chain", () => {
         status: "active",
       }),
     ]));
+    await expect(fs.access(path.join(sandbox.stateRoot, "recovery", "active.json"))).rejects.toThrow();
   });
 
   test("repairTargets recreates managed target paths from v2 projections", async () => {

--- a/packages/query/src/tests/runtime-source-v2.test.ts
+++ b/packages/query/src/tests/runtime-source-v2.test.ts
@@ -337,6 +337,38 @@ describe.sequential("runtime source v2 write chain", () => {
     await expect(fs.access(path.join(sandbox.stateRoot, "recovery", "active.json"))).rejects.toThrow();
   });
 
+  test("updateSources preflights the complete selection before committing any group", async () => {
+    const repoPath = await createRepo(sandbox.sandboxRoot, {
+      "skills/one/SKILL.md": skillDoc("one", "One."),
+    });
+    const app = new SkillFlowApp();
+    const added = await app.addSource(repoPath, {
+      sourceIdOverride: "preflight-source",
+      project: false,
+    });
+    expect(added.ok).toBe(true);
+    await writeRepoFiles(repoPath, {
+      "skills/two/SKILL.md": skillDoc("two", "Two."),
+    });
+
+    const updated = await app.updateSources(["preflight-source", "missing-source"]);
+
+    expect(updated.ok).toBe(false);
+    if (updated.ok) return;
+    expect(updated.errors[0]?.code).toBe("SOURCE_NOT_FOUND");
+    const state = await new StateStore(sandbox.stateRoot).readState();
+    expect(state.lockFile.sources["preflight-source"]?.leafIds).toEqual([
+      "preflight-source:skills/one",
+    ]);
+    await expect(fs.access(path.join(
+      state.lockFile.sources["preflight-source"]!.localPath,
+      "skills",
+      "two",
+      "SKILL.md",
+    ))).rejects.toThrow();
+    await expect(fs.access(path.join(sandbox.stateRoot, "recovery", "active.json"))).rejects.toThrow();
+  });
+
   test("repairTargets recreates managed target paths from v2 projections", async () => {
     const repoPath = await createRepo(sandbox.sandboxRoot, {
       "skills/review/SKILL.md": skillDoc("review", "Review code."),

--- a/packages/query/src/tests/state-migration-runtime.test.ts
+++ b/packages/query/src/tests/state-migration-runtime.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
 import { SkillFlowApp } from "../runtime.js";
+import { StateStore } from "@skill-flow/storage/state-store";
 import { useSkillFlowSandbox } from "./test-helpers.js";
 
 describe.sequential("state migration runtime", () => {
@@ -29,6 +30,77 @@ describe.sequential("state migration runtime", () => {
       "garrytan/gstack",
       "vercel-labs/agent-skills",
     ]);
+  });
+
+  test("non-dry-run migration blocks an inconsistent V1 authority plus recovery journal", async () => {
+    await seedV1BasicState(sandbox.stateRoot);
+    const journalPath = path.join(sandbox.stateRoot, "recovery", "active.json");
+    await writeJsonFile(journalPath, { stale: true });
+    const app = new SkillFlowApp();
+
+    await expect(app.migrateState({ to: 2, backup: false })).rejects.toMatchObject({
+      reasonCode: "RECOVERY_STATE_INCONSISTENT",
+    });
+
+    expect(JSON.parse(await fs.readFile(path.join(sandbox.stateRoot, "manifest.json"), "utf8")))
+      .toMatchObject({ schemaVersion: 1 });
+    await expect(fs.access(journalPath)).resolves.toBeUndefined();
+  });
+
+  test("dry-run migration remains read-only when a recovery journal is present", async () => {
+    await seedV1BasicState(sandbox.stateRoot);
+    const journalPath = path.join(sandbox.stateRoot, "recovery", "active.json");
+    await writeJsonFile(journalPath, { stale: true });
+    const before = await fs.readFile(path.join(sandbox.stateRoot, "manifest.json"), "utf8");
+    const app = new SkillFlowApp();
+
+    const result = await app.migrateState({ to: 2, dryRun: true, backup: false });
+
+    expect(result.status).toBe("dry-run");
+    expect(await fs.readFile(path.join(sandbox.stateRoot, "manifest.json"), "utf8")).toBe(before);
+    await expect(fs.access(journalPath)).resolves.toBeUndefined();
+  });
+
+  test("current-state migration recovers an active journal before returning current", async () => {
+    const stateStore = new StateStore(sandbox.stateRoot);
+    await stateStore.init();
+    const checkoutPath = path.join(sandbox.stateRoot, "source", "git", "repo");
+    await fs.mkdir(checkoutPath, { recursive: true });
+    await fs.writeFile(path.join(checkoutPath, "version.txt"), "old\n", "utf8");
+    const state = await stateStore.readState();
+    state.manifest.sources.push({
+      id: "repo",
+      kind: "git",
+      locator: "owner/repo",
+      canonicalLocator: "owner/repo",
+      displayName: "repo",
+      enabled: true,
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+    });
+    state.lockFile.sources.repo = {
+      sourceId: "repo",
+      canonicalLocator: "owner/repo",
+      revision: { provider: "git", commit: "old", capturedAt: "2026-08-22T00:00:00.000Z" },
+      localPath: checkoutPath,
+      leafIds: [],
+    };
+    await stateStore.writeState(state);
+    const app = new SkillFlowApp();
+    const transaction = await app.operationRecoveryService.begin({
+      kind: "update",
+      sourceId: "repo",
+      sourceKind: "git",
+    });
+    await fs.rename(checkoutPath, transaction.checkoutBackupPath!);
+    await fs.mkdir(checkoutPath, { recursive: true });
+    await fs.writeFile(path.join(checkoutPath, "version.txt"), "new\n", "utf8");
+
+    const result = await app.migrateState({ to: 2, backup: false });
+
+    expect(result.status).toBe("current");
+    expect(await fs.readFile(path.join(checkoutPath, "version.txt"), "utf8")).toBe("old\n");
+    await expect(fs.access(path.join(sandbox.stateRoot, "recovery", "active.json"))).rejects.toThrow();
   });
 });
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -2,6 +2,7 @@ export * from "./import-data-cache.js";
 export * from "./import-preparation-cache.js";
 export * from "./import-preparation-cache-store.js";
 export * from "./runtime-store.js";
+export * from "./recovery-journal-store.js";
 export * from "./source-metadata-cache.js";
 export * from "./state-schema.js";
 export * from "./state-store.js";

--- a/packages/storage/src/recovery-journal-store.ts
+++ b/packages/storage/src/recovery-journal-store.ts
@@ -1,12 +1,20 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { ImportPreparationRecord } from "@skill-flow/domain/types";
+import type {
+  DeploymentTargetId,
+  ImportPreparationRecord,
+  SourceKind,
+} from "@skill-flow/domain/types";
 import type { StateStoreState } from "./state-store.js";
 import { writeJsonFile } from "@skill-flow/integration/utils/fs";
 
 export type RecoveryOperationKind = "update" | "import";
 
 export type RecoveryPathSnapshot = {
+  role: "checkout" | "target";
+  sourceId: string;
+  sourceKind?: SourceKind;
+  target?: DeploymentTargetId;
   path: string;
   existed: boolean;
   backupName?: string;
@@ -20,6 +28,7 @@ export type RecoveryJournal = {
   transactionId: string;
   kind: RecoveryOperationKind;
   sourceId: string;
+  sourceKind: SourceKind;
   startedAt: string;
   phase: "prepared" | "mutated";
   authorityBefore: StateStoreState;
@@ -57,6 +66,7 @@ export class RecoveryJournalStore {
   }
 
   async write(journal: RecoveryJournal): Promise<void> {
+    assertRecoveryJournal(journal);
     await writeJsonFile(this.journalPath, journal);
   }
 
@@ -83,6 +93,7 @@ function assertRecoveryJournal(value: unknown): asserts value is RecoveryJournal
   if (typeof journal.sourceId !== "string" || journal.sourceId.trim().length === 0) {
     invalidJournal("missing sourceId");
   }
+  if (!isManagedSourceKind(journal.sourceKind)) invalidJournal("invalid sourceKind");
   if (typeof journal.startedAt !== "string" || Number.isNaN(Date.parse(journal.startedAt))) {
     invalidJournal("invalid startedAt");
   }
@@ -91,12 +102,37 @@ function assertRecoveryJournal(value: unknown): asserts value is RecoveryJournal
     invalidJournal("missing authority snapshot");
   }
   if (!Array.isArray(journal.targets)) invalidJournal("targets must be an array");
-  if (journal.checkout) assertPathSnapshot(journal.checkout);
-  for (const target of journal.targets ?? []) assertPathSnapshot(target);
+  if (journal.checkout) {
+    assertPathSnapshot(journal.checkout);
+    if (
+      journal.checkout.role !== "checkout"
+      || journal.checkout.sourceId !== journal.sourceId
+      || journal.checkout.sourceKind !== journal.sourceKind
+      || journal.checkout.target !== undefined
+    ) {
+      invalidJournal("checkout ownership metadata mismatch");
+    }
+  }
+  for (const target of journal.targets ?? []) {
+    assertPathSnapshot(target);
+    if (
+      target.role !== "target"
+      || target.sourceId !== journal.sourceId
+      || typeof target.target !== "string"
+      || target.target.trim().length === 0
+      || target.sourceKind !== undefined
+    ) {
+      invalidJournal("target ownership metadata mismatch");
+    }
+  }
 }
 
 function assertPathSnapshot(value: RecoveryPathSnapshot): void {
   if (!value || typeof value !== "object") invalidJournal("invalid path snapshot");
+  if (value.role !== "checkout" && value.role !== "target") invalidJournal("invalid snapshot role");
+  if (typeof value.sourceId !== "string" || value.sourceId.trim().length === 0) {
+    invalidJournal("missing snapshot sourceId");
+  }
   if (typeof value.path !== "string" || !path.isAbsolute(value.path)) {
     invalidJournal("snapshot path must be absolute");
   }
@@ -108,6 +144,10 @@ function assertPathSnapshot(value: RecoveryPathSnapshot): void {
   )) {
     invalidJournal("invalid allowed mutation fingerprints");
   }
+}
+
+function isManagedSourceKind(value: unknown): value is SourceKind {
+  return value === "git" || value === "local" || value === "clawhub";
 }
 
 function assertTransactionId(value: unknown): asserts value is string {

--- a/packages/storage/src/recovery-journal-store.ts
+++ b/packages/storage/src/recovery-journal-store.ts
@@ -10,18 +10,27 @@ import { writeJsonFile } from "@skill-flow/integration/utils/fs";
 
 export type RecoveryOperationKind = "update" | "import";
 
-export type RecoveryPathSnapshot = {
-  role: "checkout" | "target";
+type RecoveryPathSnapshotBase = {
   sourceId: string;
-  sourceKind?: SourceKind;
-  target?: DeploymentTargetId;
   path: string;
   existed: boolean;
   backupName?: string;
-  beforeFingerprint?: string;
-  mutationFingerprint?: string;
+  beforeFingerprint: string;
+};
+
+export type RecoveryCheckoutSnapshot = RecoveryPathSnapshotBase & {
+  role: "checkout";
+  sourceKind: SourceKind;
+};
+
+export type RecoveryTargetSnapshot = RecoveryPathSnapshotBase & {
+  role: "target";
+  target: DeploymentTargetId;
+  mutationFingerprint: string;
   allowedMutationFingerprints?: string[];
 };
+
+export type RecoveryPathSnapshot = RecoveryCheckoutSnapshot | RecoveryTargetSnapshot;
 
 export type RecoveryJournal = {
   schemaVersion: 1;
@@ -33,8 +42,8 @@ export type RecoveryJournal = {
   phase: "prepared" | "mutated";
   authorityBefore: StateStoreState;
   importPreparationBefore?: ImportPreparationRecord;
-  checkout?: RecoveryPathSnapshot;
-  targets: RecoveryPathSnapshot[];
+  checkout?: RecoveryCheckoutSnapshot;
+  targets: RecoveryTargetSnapshot[];
 };
 
 export class RecoveryJournalStore {
@@ -108,7 +117,6 @@ function assertRecoveryJournal(value: unknown): asserts value is RecoveryJournal
       journal.checkout.role !== "checkout"
       || journal.checkout.sourceId !== journal.sourceId
       || journal.checkout.sourceKind !== journal.sourceKind
-      || journal.checkout.target !== undefined
     ) {
       invalidJournal("checkout ownership metadata mismatch");
     }
@@ -120,7 +128,6 @@ function assertRecoveryJournal(value: unknown): asserts value is RecoveryJournal
       || target.sourceId !== journal.sourceId
       || typeof target.target !== "string"
       || target.target.trim().length === 0
-      || target.sourceKind !== undefined
     ) {
       invalidJournal("target ownership metadata mismatch");
     }
@@ -144,11 +151,13 @@ function assertPathSnapshot(value: RecoveryPathSnapshot): void {
     invalidJournal("missing target mutation fingerprint");
   }
   if (value.backupName !== undefined) assertBackupName(value.backupName);
-  if (value.allowedMutationFingerprints !== undefined && (
-    !Array.isArray(value.allowedMutationFingerprints)
-    || value.allowedMutationFingerprints.some((entry) => typeof entry !== "string")
-  )) {
-    invalidJournal("invalid allowed mutation fingerprints");
+  if (value.role === "target") {
+    if (value.allowedMutationFingerprints !== undefined && (
+      !Array.isArray(value.allowedMutationFingerprints)
+      || value.allowedMutationFingerprints.some((entry: unknown) => typeof entry !== "string")
+    )) {
+      invalidJournal("invalid allowed mutation fingerprints");
+    }
   }
 }
 

--- a/packages/storage/src/recovery-journal-store.ts
+++ b/packages/storage/src/recovery-journal-store.ts
@@ -32,19 +32,29 @@ export type RecoveryTargetSnapshot = RecoveryPathSnapshotBase & {
 
 export type RecoveryPathSnapshot = RecoveryCheckoutSnapshot | RecoveryTargetSnapshot;
 
-export type RecoveryJournal = {
+type RecoveryJournalBase = {
   schemaVersion: 1;
   transactionId: string;
-  kind: RecoveryOperationKind;
   sourceId: string;
   sourceKind: SourceKind;
   startedAt: string;
   phase: "prepared" | "mutated";
   authorityBefore: StateStoreState;
-  importPreparationBefore?: ImportPreparationRecord;
-  checkout?: RecoveryCheckoutSnapshot;
+  checkout: RecoveryCheckoutSnapshot;
   targets: RecoveryTargetSnapshot[];
 };
+
+export type RecoveryUpdateJournal = RecoveryJournalBase & {
+  kind: "update";
+  importPreparationBefore?: never;
+};
+
+export type RecoveryImportJournal = RecoveryJournalBase & {
+  kind: "import";
+  importPreparationBefore: ImportPreparationRecord;
+};
+
+export type RecoveryJournal = RecoveryUpdateJournal | RecoveryImportJournal;
 
 export class RecoveryJournalStore {
   constructor(private readonly stateRoot: string) {}
@@ -111,15 +121,19 @@ function assertRecoveryJournal(value: unknown): asserts value is RecoveryJournal
     invalidJournal("missing authority snapshot");
   }
   if (!Array.isArray(journal.targets)) invalidJournal("targets must be an array");
-  if (journal.checkout) {
-    assertPathSnapshot(journal.checkout);
-    if (
-      journal.checkout.role !== "checkout"
-      || journal.checkout.sourceId !== journal.sourceId
-      || journal.checkout.sourceKind !== journal.sourceKind
-    ) {
-      invalidJournal("checkout ownership metadata mismatch");
-    }
+  if (!journal.checkout) invalidJournal("missing checkout snapshot");
+  assertPathSnapshot(journal.checkout);
+  if (
+    journal.checkout.role !== "checkout"
+    || journal.checkout.sourceId !== journal.sourceId
+    || journal.checkout.sourceKind !== journal.sourceKind
+  ) {
+    invalidJournal("checkout ownership metadata mismatch");
+  }
+  if (journal.kind === "import") {
+    if (!journal.importPreparationBefore) invalidJournal("missing import preparation snapshot");
+  } else if (journal.importPreparationBefore !== undefined) {
+    invalidJournal("update journal cannot contain import preparation snapshot");
   }
   for (const target of journal.targets ?? []) {
     assertPathSnapshot(target);

--- a/packages/storage/src/recovery-journal-store.ts
+++ b/packages/storage/src/recovery-journal-store.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ImportPreparationRecord } from "@skill-flow/domain/types";
+import type { StateStoreState } from "./state-store.js";
+import { writeJsonFile } from "@skill-flow/integration/utils/fs";
+
+export type RecoveryOperationKind = "update" | "import";
+
+export type RecoveryPathSnapshot = {
+  path: string;
+  existed: boolean;
+  backupName?: string;
+  beforeFingerprint?: string;
+  mutationFingerprint?: string;
+  allowedMutationFingerprints?: string[];
+};
+
+export type RecoveryJournal = {
+  schemaVersion: 1;
+  transactionId: string;
+  kind: RecoveryOperationKind;
+  sourceId: string;
+  startedAt: string;
+  phase: "prepared" | "mutated";
+  authorityBefore: StateStoreState;
+  importPreparationBefore?: ImportPreparationRecord;
+  checkout?: RecoveryPathSnapshot;
+  targets: RecoveryPathSnapshot[];
+};
+
+export class RecoveryJournalStore {
+  constructor(private readonly stateRoot: string) {}
+
+  get recoveryRoot(): string {
+    return path.join(this.stateRoot, "recovery");
+  }
+
+  get journalPath(): string {
+    return path.join(this.recoveryRoot, "active.json");
+  }
+
+  backupPath(transactionId: string, backupName: string): string {
+    assertTransactionId(transactionId);
+    assertBackupName(backupName);
+    return safeRecoveryChild(this.recoveryRoot, transactionId, backupName);
+  }
+
+  async read(): Promise<RecoveryJournal | undefined> {
+    try {
+      const parsed: unknown = JSON.parse(await fs.readFile(this.journalPath, "utf8"));
+      assertRecoveryJournal(parsed);
+      return parsed;
+    } catch (error) {
+      if (isMissing(error)) return undefined;
+      throw error;
+    }
+  }
+
+  async write(journal: RecoveryJournal): Promise<void> {
+    await writeJsonFile(this.journalPath, journal);
+  }
+
+  async clear(journal: RecoveryJournal): Promise<void> {
+    assertRecoveryJournal(journal);
+    await fs.rm(this.journalPath, { force: true });
+    await fs.rm(safeRecoveryChild(this.recoveryRoot, journal.transactionId), {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
+}
+
+function assertRecoveryJournal(value: unknown): asserts value is RecoveryJournal {
+  if (!value || typeof value !== "object") invalidJournal("root must be an object");
+  const journal = value as Partial<RecoveryJournal>;
+  if (journal.schemaVersion !== 1) invalidJournal("unsupported schemaVersion");
+  assertTransactionId(journal.transactionId);
+  if (journal.kind !== "update" && journal.kind !== "import") invalidJournal("invalid operation kind");
+  if (typeof journal.sourceId !== "string" || journal.sourceId.trim().length === 0) {
+    invalidJournal("missing sourceId");
+  }
+  if (typeof journal.startedAt !== "string" || Number.isNaN(Date.parse(journal.startedAt))) {
+    invalidJournal("invalid startedAt");
+  }
+  if (journal.phase !== "prepared" && journal.phase !== "mutated") invalidJournal("invalid phase");
+  if (!journal.authorityBefore || typeof journal.authorityBefore !== "object") {
+    invalidJournal("missing authority snapshot");
+  }
+  if (!Array.isArray(journal.targets)) invalidJournal("targets must be an array");
+  if (journal.checkout) assertPathSnapshot(journal.checkout);
+  for (const target of journal.targets ?? []) assertPathSnapshot(target);
+}
+
+function assertPathSnapshot(value: RecoveryPathSnapshot): void {
+  if (!value || typeof value !== "object") invalidJournal("invalid path snapshot");
+  if (typeof value.path !== "string" || !path.isAbsolute(value.path)) {
+    invalidJournal("snapshot path must be absolute");
+  }
+  if (typeof value.existed !== "boolean") invalidJournal("snapshot existed flag must be boolean");
+  if (value.backupName !== undefined) assertBackupName(value.backupName);
+  if (value.allowedMutationFingerprints !== undefined && (
+    !Array.isArray(value.allowedMutationFingerprints)
+    || value.allowedMutationFingerprints.some((entry) => typeof entry !== "string")
+  )) {
+    invalidJournal("invalid allowed mutation fingerprints");
+  }
+}
+
+function assertTransactionId(value: unknown): asserts value is string {
+  if (
+    typeof value !== "string"
+    || !/^recovery-[1-9]\d*-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+  ) {
+    invalidJournal("invalid transactionId");
+  }
+}
+
+function assertBackupName(value: unknown): asserts value is string {
+  if (typeof value !== "string" || !/^(checkout|target-\d+)$/.test(value)) {
+    invalidJournal("invalid backup name");
+  }
+}
+
+function safeRecoveryChild(root: string, ...segments: string[]): string {
+  const resolvedRoot = path.resolve(root);
+  const candidate = path.resolve(resolvedRoot, ...segments);
+  if (!candidate.startsWith(`${resolvedRoot}${path.sep}`)) invalidJournal("recovery path escapes root");
+  return candidate;
+}
+
+function invalidJournal(reason: string): never {
+  throw new Error(`Invalid recovery journal: ${reason}.`);
+}

--- a/packages/storage/src/recovery-journal-store.ts
+++ b/packages/storage/src/recovery-journal-store.ts
@@ -137,6 +137,12 @@ function assertPathSnapshot(value: RecoveryPathSnapshot): void {
     invalidJournal("snapshot path must be absolute");
   }
   if (typeof value.existed !== "boolean") invalidJournal("snapshot existed flag must be boolean");
+  if (typeof value.beforeFingerprint !== "string" || value.beforeFingerprint.length === 0) {
+    invalidJournal("missing snapshot before fingerprint");
+  }
+  if (value.role === "target" && (typeof value.mutationFingerprint !== "string" || value.mutationFingerprint.length === 0)) {
+    invalidJournal("missing target mutation fingerprint");
+  }
   if (value.backupName !== undefined) assertBackupName(value.backupName);
   if (value.allowedMutationFingerprints !== undefined && (
     !Array.isArray(value.allowedMutationFingerprints)

--- a/packages/storage/src/state-store.ts
+++ b/packages/storage/src/state-store.ts
@@ -188,23 +188,24 @@ export class StateStore {
   async writeState(state: StateStoreState): Promise<void> {
     await this.withIoLock(async () => {
       await this.init();
-      const normalizedLock = normalizeLockFile(state.lockFile);
-      assertManifestFile(state.manifest, this.manifestPath);
-      assertLockFile(normalizedLock, this.lockPath);
-      assertPreferencesFile(state.preferences, this.preferencesPath);
-      assertCollectionsFile(state.collections, this.collectionsPath);
-      assertMigrationGenerationMatch(
-        this.stateRoot,
-        state.manifest,
-        normalizedLock,
-        state.preferences,
-        state.collections,
-      );
-      await writeAuthorityStateTransaction(this.stateRoot, {
-        ...state,
-        lockFile: normalizedLock,
-      });
+      await writeAuthorityStateTransaction(this.stateRoot, this.validateState(state));
     });
+  }
+
+  validateState(state: StateStoreState): StateStoreState {
+    const normalizedLock = normalizeLockFile(state.lockFile);
+    assertManifestFile(state.manifest, this.manifestPath);
+    assertLockFile(normalizedLock, this.lockPath);
+    assertPreferencesFile(state.preferences, this.preferencesPath);
+    assertCollectionsFile(state.collections, this.collectionsPath);
+    assertMigrationGenerationMatch(
+      this.stateRoot,
+      state.manifest,
+      normalizedLock,
+      state.preferences,
+      state.collections,
+    );
+    return { ...state, lockFile: normalizedLock };
   }
 
   async withMutationLock<T>(task: () => Promise<T>): Promise<T> {

--- a/packages/storage/src/tests/recovery-journal-store.test.ts
+++ b/packages/storage/src/tests/recovery-journal-store.test.ts
@@ -33,4 +33,23 @@ describe("RecoveryJournalStore", () => {
     await expect(store.read()).rejects.toThrow(/invalid recovery journal/i);
     await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("keep\n");
   });
+
+  test("rejects an experimental v1 journal that lacks semantic ownership fields", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-store-"));
+    roots.push(stateRoot);
+    const store = new RecoveryJournalStore(stateRoot);
+    await fs.mkdir(path.dirname(store.journalPath), { recursive: true });
+    await fs.writeFile(store.journalPath, JSON.stringify({
+      schemaVersion: 1,
+      transactionId: "recovery-123-12345678-1234-4123-8123-123456789abc",
+      kind: "update",
+      sourceId: "repo",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      phase: "prepared",
+      authorityBefore: {},
+      targets: [],
+    }), "utf8");
+
+    await expect(store.read()).rejects.toThrow(/invalid sourceKind/i);
+  });
 });

--- a/packages/storage/src/tests/recovery-journal-store.test.ts
+++ b/packages/storage/src/tests/recovery-journal-store.test.ts
@@ -52,4 +52,59 @@ describe("RecoveryJournalStore", () => {
 
     await expect(store.read()).rejects.toThrow(/invalid sourceKind/i);
   });
+
+  test("rejects target snapshots without required fingerprints", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-store-"));
+    roots.push(stateRoot);
+    const store = new RecoveryJournalStore(stateRoot);
+    await fs.mkdir(path.dirname(store.journalPath), { recursive: true });
+    await fs.writeFile(store.journalPath, JSON.stringify({
+      schemaVersion: 1,
+      transactionId: "recovery-123-12345678-1234-4123-8123-123456789abc",
+      kind: "update",
+      sourceId: "repo",
+      sourceKind: "git",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      phase: "mutated",
+      authorityBefore: {},
+      targets: [{
+        role: "target",
+        sourceId: "repo",
+        target: "codex",
+        path: path.join(stateRoot, "targets", "codex", "review"),
+        existed: true,
+        backupName: "target-0",
+      }],
+    }), "utf8");
+
+    await expect(store.read()).rejects.toThrow(/missing snapshot before fingerprint/i);
+  });
+
+  test("rejects target snapshots without a mutation fingerprint", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-store-"));
+    roots.push(stateRoot);
+    const store = new RecoveryJournalStore(stateRoot);
+    await fs.mkdir(path.dirname(store.journalPath), { recursive: true });
+    await fs.writeFile(store.journalPath, JSON.stringify({
+      schemaVersion: 1,
+      transactionId: "recovery-123-12345678-1234-4123-8123-123456789abc",
+      kind: "update",
+      sourceId: "repo",
+      sourceKind: "git",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      phase: "mutated",
+      authorityBefore: {},
+      targets: [{
+        role: "target",
+        sourceId: "repo",
+        target: "codex",
+        path: path.join(stateRoot, "targets", "codex", "review"),
+        existed: true,
+        backupName: "target-0",
+        beforeFingerprint: "before",
+      }],
+    }), "utf8");
+
+    await expect(store.read()).rejects.toThrow(/missing target mutation fingerprint/i);
+  });
 });

--- a/packages/storage/src/tests/recovery-journal-store.test.ts
+++ b/packages/storage/src/tests/recovery-journal-store.test.ts
@@ -67,6 +67,7 @@ describe("RecoveryJournalStore", () => {
       startedAt: "2026-08-22T00:00:00.000Z",
       phase: "mutated",
       authorityBefore: {},
+      checkout: checkoutSnapshot(stateRoot),
       targets: [{
         role: "target",
         sourceId: "repo",
@@ -94,6 +95,7 @@ describe("RecoveryJournalStore", () => {
       startedAt: "2026-08-22T00:00:00.000Z",
       phase: "mutated",
       authorityBefore: {},
+      checkout: checkoutSnapshot(stateRoot),
       targets: [{
         role: "target",
         sourceId: "repo",
@@ -107,4 +109,57 @@ describe("RecoveryJournalStore", () => {
 
     await expect(store.read()).rejects.toThrow(/missing target mutation fingerprint/i);
   });
+
+  test("rejects update journals without a checkout snapshot", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-store-"));
+    roots.push(stateRoot);
+    const store = new RecoveryJournalStore(stateRoot);
+    await fs.mkdir(path.dirname(store.journalPath), { recursive: true });
+    await fs.writeFile(store.journalPath, JSON.stringify({
+      schemaVersion: 1,
+      transactionId: "recovery-123-12345678-1234-4123-8123-123456789abc",
+      kind: "update",
+      sourceId: "repo",
+      sourceKind: "git",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      phase: "prepared",
+      authorityBefore: {},
+      targets: [],
+    }), "utf8");
+
+    await expect(store.read()).rejects.toThrow(/missing checkout snapshot/i);
+  });
+
+  test("rejects import journals without a preparation snapshot", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-store-"));
+    roots.push(stateRoot);
+    const store = new RecoveryJournalStore(stateRoot);
+    await fs.mkdir(path.dirname(store.journalPath), { recursive: true });
+    await fs.writeFile(store.journalPath, JSON.stringify({
+      schemaVersion: 1,
+      transactionId: "recovery-123-12345678-1234-4123-8123-123456789abc",
+      kind: "import",
+      sourceId: "repo",
+      sourceKind: "git",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      phase: "prepared",
+      authorityBefore: {},
+      checkout: checkoutSnapshot(stateRoot),
+      targets: [],
+    }), "utf8");
+
+    await expect(store.read()).rejects.toThrow(/missing import preparation snapshot/i);
+  });
 });
+
+function checkoutSnapshot(stateRoot: string): Record<string, unknown> {
+  return {
+    role: "checkout",
+    sourceId: "repo",
+    sourceKind: "git",
+    path: path.join(stateRoot, "source", "git", "repo"),
+    existed: true,
+    backupName: "checkout",
+    beforeFingerprint: "before",
+  };
+}

--- a/packages/storage/src/tests/recovery-journal-store.test.ts
+++ b/packages/storage/src/tests/recovery-journal-store.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { RecoveryJournalStore } from "../recovery-journal-store.js";
+
+describe("RecoveryJournalStore", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+  });
+
+  test("rejects a journal transaction id that escapes the recovery root", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "skill-flow-recovery-store-"));
+    roots.push(parent);
+    const stateRoot = path.join(parent, "state");
+    const store = new RecoveryJournalStore(stateRoot);
+    const sentinel = path.join(parent, "keep.txt");
+    await fs.mkdir(path.dirname(store.journalPath), { recursive: true });
+    await fs.writeFile(sentinel, "keep\n", "utf8");
+    await fs.writeFile(store.journalPath, JSON.stringify({
+      schemaVersion: 1,
+      transactionId: "../..",
+      kind: "update",
+      sourceId: "repo",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      phase: "prepared",
+      authorityBefore: {},
+      targets: [],
+    }), "utf8");
+
+    await expect(store.read()).rejects.toThrow(/invalid recovery journal/i);
+    await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("keep\n");
+  });
+});


### PR DESCRIPTION
## Summary

This PR makes macOS application termination safe while managed Update or final Import work is running.

It:

1. Coordinates Command-Q and the application Quit menu with active bridge helpers.
2. Stops active update, import preparation, import commit, search, scan, and preview helper process groups before termination.
3. Adds durable per-group recovery for managed Update and final Import.
4. Recovers interrupted state before bootstrap prunes missing checkouts or starts another protected mutation.
5. Validates journal authority and path ownership before any recovery filesystem operation.
6. Preserves the existing per-group partial-update model after a complete batch preflight.
7. Keeps ordinary command timeout behavior and the existing public bridge command surface unchanged.

## Motivation

The macOS app currently exits without coordinating active bridge helpers.

During a managed Git source update, the Node bridge helper holds Skill Flow's global `.mutation.lock` while it runs Git operations and replaces checkout and authority data. The helper—not the Git child process—is the recorded lock owner.

If the helper outlives the application, a quick relaunch starts a new bootstrap helper that needs the same mutation lock. Upstream lock handling correctly refuses to reclaim a lock owned by a live PID. The new bootstrap therefore waits until the desktop command reaches its 60-second deadline, before managed-group summaries have been returned and applied to the UI.

The immediate symptom is that existing managed groups are unavailable after restart. They have not necessarily been deleted; startup failed before loading them.

There is also a narrower persistent-state risk. Managed checkout replacement currently performs these steps:

1. Rename the canonical checkout to a backup.
2. Rename the prepared checkout into the canonical path.
3. Write updated authority state.
4. Remove the backup.

The existing rollback handles exceptions inside the running process, but it cannot run after abrupt process termination. If termination occurs between the two checkout renames, the canonical checkout is temporarily absent. A later successful bootstrap runs missing-checkout pruning before loading summaries and may remove the registered source, binding, inventory, and projections.

Deleting `.mutation.lock` on startup would not be safe: a live owner may still be mutating authority state. Application lifecycle cancellation and durable transaction recovery are both required.

## Core changes

### Coordinated application Quit

Command-Q and the application Quit menu now:

- freeze the session Group Operation Queue;
- reject new protected work;
- discard queued operations without replaying them;
- stop every active cancellable bridge helper before recovery;
- delay application termination until durable recovery completes.

Closing the main window retains its existing behavior and does not trigger operation cancellation.

Helpers are registered atomically with their operation role so Quit cannot race with helper launch. The desktop sends cooperative termination to all relevant helper process groups, waits five seconds, and force-kills surviving groups.

This ensures that the Node helper holding `.mutation.lock`, together with Git or archive descendants, cannot continue mutating state after the desktop exits.

### Durable managed-operation recovery

Managed Update and final Import write a private recovery journal before mutation.

The journal records:

- operation and source identity;
- managed source kind;
- the validated pre-operation authority snapshot;
- canonical checkout ownership and recovery evidence;
- Skill Flow-owned target identities, fingerprints, and backups;
- the previous import-preparation record when applicable.

A managed group reaches its commit point only when its checkout, authority state, and owned target projections describe the same version.

Recovery restores the incomplete group in this order:

1. Validate the complete journal and authority snapshot.
2. Validate checkout, preparation, and target ownership.
3. Check all target fingerprints for external changes.
4. Restore the managed checkout.
5. Restore authority state.
6. Restore owned targets and import-preparation state.
7. Clear the journal and backups.

A target changed outside the interrupted operation produces a recovery conflict instead of being overwritten.

External sources and collections do not enter the managed recovery path.

### Startup and migration ordering

Bootstrap now recovers an unfinished operation before missing-checkout pruning and ordinary reconciliation.

This prevents an interrupted checkout replacement from being interpreted as a permanently missing managed source.

State migration uses the same schema-independent mutation lock:

- current V2 state recovers an active journal before returning `current`;
- V1 state combined with a recovery journal is rejected as inconsistent;
- dry-run migration remains read-only.

Interrupted disposable import preparations are cleaned during bootstrap. Their cleanup failure does not block application Quit and is retried at the next launch.

### Bulk Update and Import boundaries

Bulk Update retains per-group commits, but validates the complete selected source list before starting the first group transaction. An invalid later source therefore cannot leave earlier sources updated before validation completes.

After preflight succeeds, previously committed groups remain committed if a later group is interrupted; recovery affects only the current incomplete group.

The desktop final Import path now always uses explicit preparation followed by commit, allowing the durable boundary to cover the final mutation. The existing bridge command catalog and payload formats remain compatible.

### Recovery Required state

If durable recovery fails, the application remains open and offers Retry Recovery or Cancel Quit.

After Cancel Quit:

- import search, local scan, and preview remain available;
- import preparation, final Import, and Update remain blocked;
- another Quit or Retry Recovery attempts recovery again.

Successful recovery opens a fresh empty session queue. Interrupted or discarded operations are never resumed automatically.

### Timeout compatibility

Process-group termination is limited to application Quit.

Ordinary command timeout preserves the established helper-only behavior: it terminates the launched helper, waits the existing grace period, and force-kills that helper if necessary. This avoids broadening timeout semantics outside the application lifecycle boundary.

## Verification

- `npm run build`
- `@skill-flow/storage`: recovery journal tests — 2 passed
- `@skill-flow/core-engine`: operation recovery tests — 8 passed
- `@skill-flow/query`: recovery, migration, and full-selection preflight tests — 22 passed
- Swift source parse checks passed
- GitHub Actions on macOS 26 / Xcode 26.5:
  - JavaScript build passed
  - updated-source workflow tests passed
  - macOS production target compiled
  - arm64 ZIP and DMG packaging passed
  - ad-hoc signature, macOS 15.0 minimum version, and SDK 26.5 checks passed

Build run: https://github.com/Lowerce/skill-flow/actions/runs/32558241874

---

## 中文概要

本 PR 使 macOS 应用在托管来源更新或最终导入仍在运行时能够安全退出。

主要改进包括：

1. 让 Command-Q 和应用菜单“退出”与活动 bridge helper 协同。
2. 退出前停止正在运行的更新、导入准备、最终导入、搜索、扫描和预览 helper 进程组。
3. 为托管 Update 和最终 Import 增加逐组持久恢复。
4. 在 bootstrap 清理缺失 checkout 或开始新的受保护写入前恢复中断状态。
5. 在任何恢复文件操作前验证 journal、authority snapshot 和路径所有权。
6. 在完整批量预检后继续沿用现有的逐组提交和 partial-update 模型。
7. 保持普通命令超时行为及现有公开 bridge 命令接口不变。

## 背景

macOS 应用当前退出时不会协调仍在运行的 bridge helper。

托管 Git 来源更新期间，Node bridge helper 会在执行 Git 操作、替换 checkout 和写入 authority state 时持有 Skill Flow 的全局 `.mutation.lock`。锁中记录的 owner 是 Node helper，而不是 Git 子进程。

如果应用退出后该 helper 继续存活，快速重启产生的新 bootstrap helper 也需要取得同一把 mutation lock。上游的锁策略会正确拒绝回收仍由存活 PID 持有的锁，因此新的 bootstrap 会持续等待，最后先达到桌面端 60 秒命令时限。此时托管分组 summaries 尚未返回并写入 UI，表现为重启后当前托管分组无法显示。

这个即时现象并不一定表示托管 skills 已被删除，而是启动在加载它们之前失败。

此外还存在一个更窄的持久状态风险。当前托管 checkout 替换依次执行：

1. 将规范 checkout 重命名为 backup。
2. 将准备好的 checkout 移入规范路径。
3. 写入新的 authority state。
4. 删除 backup。

现有 rollback 只能处理运行中进程捕获到的异常，无法在进程被突然终止后继续执行。如果退出发生在两次 checkout rename 之间，规范 checkout 会暂时缺失。后续成功取得锁的 bootstrap 会先执行 missing-checkout prune，并可能删除该来源的注册、binding、inventory 和 projections。

启动时直接删除 `.mutation.lock` 并不安全，因为存活 owner 可能仍在写入状态。因此，本问题需要同时解决应用生命周期取消和中断事务恢复。

## 核心改进

### 协调应用退出

Command-Q 和应用菜单“退出”现在会：

- 冻结当前会话的 Group Operation Queue；
- 拒绝新的受保护操作；
- 丢弃尚未运行的排队操作且不自动重放；
- 在恢复前停止所有活动的可取消 bridge helper；
- 等待持久恢复完成后再退出程序。

仅关闭主窗口继续保持原有行为，不会中止操作。

helper 会在启动边界原子登记其操作类别，避免退出锁存状态与 helper 启动产生竞态。应用首先向相关 helper 进程组发送协作终止信号，等待五秒后强制结束仍存活的进程组。

因此，持有 `.mutation.lock` 的 Node helper 以及其 Git 或 archive 后代进程不会在桌面应用退出后继续修改状态。

### 托管操作的持久恢复

托管 Update 和最终 Import 会在开始修改前写入私有 recovery journal。

Journal 记录：

- 操作和来源身份；
- 托管来源类型；
- 经过验证的操作前 authority snapshot；
- 规范 checkout 的所有权及恢复证据；
- Skill Flow 所有 target 的身份、fingerprint 和 backup；
- 必要时记录操作前的 import preparation。

只有 checkout、authority state 和 Skill Flow 所有 target projections 描述同一版本时，该分组才到达提交点。

恢复顺序为：

1. 验证完整 journal 和 authority snapshot。
2. 验证 checkout、preparation 和 target 所有权。
3. 检查所有 target fingerprint 是否存在外部修改。
4. 恢复托管 checkout。
5. 恢复 authority state。
6. 恢复 Skill Flow 所有 target 和 import preparation。
7. 清除 journal 和 backup。

如果 target 在中断操作之外发生变化，恢复会报告冲突，而不会自动覆盖该路径。

External source 和 collection 不进入托管恢复路径。

### 启动和迁移顺序

Bootstrap 会在 missing-checkout prune 和普通 reconciliation 之前恢复未完成的操作。

这样可以避免把更新过程中暂时缺失的规范 checkout 误判为永久丢失的托管来源。

状态迁移使用同一把与 schema 无关的 mutation lock：

- 当前 V2 状态会先恢复活动 journal，再返回 `current`；
- V1 状态与 recovery journal 同时存在时会作为不一致状态停止；
- dry-run migration 保持严格只读。

中断的临时导入准备会在 bootstrap 时清理。该清理失败不会阻止退出，并会在下次启动时重试。

### 批量更新和导入边界

Bulk Update 继续逐组提交，但会在第一个分组事务开始前验证完整的来源选择列表。因此，后续来源无效时，不会在完成验证前留下已更新的前序来源。

完整预检成功后，如果后续分组被中断，之前已经提交的分组保持提交，只恢复当前未完成分组。

桌面端最终 Import 现在始终先执行 preparation，再执行 commit，使最终写入能够进入持久恢复边界。现有 bridge 命令目录和 payload 格式保持兼容。

### Recovery Required 状态

持久恢复失败时，应用保持打开，并提供 Retry Recovery 和 Cancel Quit。

取消退出后：

- import search、local scan 和 preview 仍可使用；
- import preparation、最终 Import 和 Update 保持禁用；
- 再次退出或选择 Retry Recovery 时会重新尝试恢复。

恢复成功后会重新打开一个空的会话队列。被中断或丢弃的操作不会自动继续。

### 超时兼容性

进程组终止仅用于应用退出。

普通命令超时继续遵循既有的仅终止 helper 行为：先终止所启动的 helper，等待现有 grace period，必要时再强制结束该 helper。这避免了应用退出之外的超时语义扩张。

## 验证

- `npm run build`
- `@skill-flow/storage`：recovery journal 测试 2 项通过
- `@skill-flow/core-engine`：operation recovery 测试 8 项通过
- `@skill-flow/query`：recovery、migration 和完整批量预检测试 22 项通过
- Swift 源码解析检查通过
- GitHub Actions，macOS 26 / Xcode 26.5：
  - JavaScript 构建通过
  - 更新专项测试通过
  - macOS production target 编译通过
  - arm64 ZIP 和 DMG 打包通过
  - ad-hoc 签名、macOS 15.0 最低版本和 SDK 26.5 校验通过

构建记录：https://github.com/Lowerce/skill-flow/actions/runs/32558241874
