### PR TITLE
fix(desktop): 更新后保持当前详情内容最新

### DIFF
--- a/apps/desktop-mac/Sources/DesktopApp/App/DesktopAppContainer.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/App/DesktopAppContainer.swift
@@ -71,11 +71,8 @@ final class DesktopAppContainer {
             toastPresenter: { [weak mainViewModel] style, message in
                 mainViewModel?.presentToast(style: style, message: message)
             },
-            hasInspectPayload: { [weak mainViewModel] sourceId in
-                mainViewModel?.hasInspectPayload(for: sourceId) ?? false
-            },
-            isInspectRequestInFlight: { [weak mainViewModel] sourceId in
-                mainViewModel?.isInspectRequestInFlight(for: sourceId) ?? false
+            shouldInspectDetail: { [weak mainViewModel] sourceId in
+                mainViewModel?.shouldInspectDetail(for: sourceId) ?? false
             },
             isUpdatingCurrentGroup: { [weak mainViewModel] in
                 mainViewModel?.isUpdatingCurrentGroup ?? false

--- a/apps/desktop-mac/Sources/DesktopApp/Resources/en.lproj/Localizable.strings
+++ b/apps/desktop-mac/Sources/DesktopApp/Resources/en.lproj/Localizable.strings
@@ -514,4 +514,6 @@
 "usage.error.refresh" = "Unable to refresh skill usage.";
 "detail.document.default_title" = "Document";
 "detail.document.unavailable" = "%@ unavailable.";
+"toast.update.detail_refresh_failed" = "The group was updated, but its details could not be refreshed. Reopen the group to retry.";
+"toast.update.partial_detail_refresh_failed" = "%@ groups updated, %@ failed (%@). The open group details may be stale; reopen it to retry.";
 "test.fallback.only_en" = "Only English";

--- a/apps/desktop-mac/Sources/DesktopApp/Resources/ja.lproj/Localizable.strings
+++ b/apps/desktop-mac/Sources/DesktopApp/Resources/ja.lproj/Localizable.strings
@@ -514,3 +514,5 @@
 "usage.error.refresh" = "スキルの使用状況を更新できませんでした。";
 "detail.document.default_title" = "ドキュメント";
 "detail.document.unavailable" = "%@ を利用できません。";
+"toast.update.detail_refresh_failed" = "グループは更新されましたが、詳細を更新できませんでした。グループを開き直すと再試行できます。";
+"toast.update.partial_detail_refresh_failed" = "%@ 件のグループを更新し、%@ 件が失敗しました（%@）。開いているグループの詳細は古い可能性があります。開き直すと再試行できます。";

--- a/apps/desktop-mac/Sources/DesktopApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/desktop-mac/Sources/DesktopApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -514,3 +514,5 @@
 "usage.error.refresh" = "无法刷新技能使用记录。";
 "detail.document.default_title" = "文档";
 "detail.document.unavailable" = "%@ 不可用。";
+"toast.update.detail_refresh_failed" = "分组已更新，但详情刷新失败。重新打开该分组即可重试。";
+"toast.update.partial_detail_refresh_failed" = "%@ 个分组已更新，%@ 个失败（%@）。当前分组详情可能已过期；重新打开即可重试。";

--- a/apps/desktop-mac/Sources/DesktopApp/Screens/Detail/DetailScreen.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Screens/Detail/DetailScreen.swift
@@ -15,7 +15,27 @@ enum DetailRouteBootstrap {
         guard let detail else {
             return
         }
-        if state.detailSkillIdByGroup[sourceId] == nil {
+        let availableSkillIds = Set(detail.skills.map(\.id))
+        if availableSkillIds.isEmpty {
+            if let removedSkillId = state.detailSkillIdByGroup.removeValue(forKey: sourceId) {
+                state.detailDocumentTabIdBySkill.removeValue(forKey: removedSkillId)
+            }
+            state.pendingDetailSkillIdByGroup.removeValue(forKey: sourceId)
+            state.detailShowsGroupOverviewByGroup[sourceId] = true
+            state.detailSelectedTreeItemIdByGroup.removeValue(forKey: sourceId)
+            state.detailHoveredItemIdByGroup.removeValue(forKey: sourceId)
+            return
+        }
+        if let pendingSkillId = state.pendingDetailSkillIdByGroup[sourceId],
+           !availableSkillIds.contains(pendingSkillId) {
+            state.pendingDetailSkillIdByGroup.removeValue(forKey: sourceId)
+        }
+        if let selectedSkillId = state.detailSkillIdByGroup[sourceId],
+           !availableSkillIds.contains(selectedSkillId) {
+            state.detailDocumentTabIdBySkill.removeValue(forKey: selectedSkillId)
+            state.detailSkillIdByGroup[sourceId] = preferredDetailSkillId(for: detail)
+            state.detailSelectedTreeItemIdByGroup.removeValue(forKey: sourceId)
+        } else if state.detailSkillIdByGroup[sourceId] == nil {
             state.detailSkillIdByGroup[sourceId] = preferredDetailSkillId(for: detail)
         }
         if state.detailDocumentTabIdByGroup[sourceId] == nil {
@@ -30,10 +50,6 @@ enum DetailRouteBootstrap {
            let treeItemId = detail.fileTree.skillRootItemId(for: selectedSkillId) {
             state.detailSelectedTreeItemIdByGroup[sourceId] = treeItemId
         }
-    }
-
-    static func shouldFetchInspect(hasInspectPayload: Bool, isInspectRequestInFlight: Bool) -> Bool {
-        !hasInspectPayload && !isInspectRequestInFlight
     }
 
     @MainActor
@@ -182,24 +198,15 @@ struct DetailScreen: View {
                 .padding(16)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 .task(id: sourceId) {
-                    await bootstrapDetailRoute(sourceId: sourceId, detail: detail)
+                    await container.enterDetail(sourceId: sourceId)
+                }
+                .onChange(of: container.detailRevision) {
+                    container.reconcileDetailSelection(sourceId: sourceId)
                 }
             } else {
                 EmptyView()
             }
         }
-    }
-
-    private func bootstrapDetailRoute(sourceId: String, detail: DetailViewModel?) async {
-        DetailRouteBootstrap.applySelections(state: screenState, sourceId: sourceId, detail: detail)
-        guard DetailRouteBootstrap.shouldFetchInspect(
-            hasInspectPayload: container.hasInspectPayload(for: sourceId),
-            isInspectRequestInFlight: container.isInspectRequestInFlight(for: sourceId)
-        ) else {
-            return
-        }
-        await container.selectSource(sourceId)
-        DetailRouteBootstrap.applySelections(state: screenState, sourceId: sourceId, detail: container.viewModel)
     }
 
     private func detailSidebar(

--- a/apps/desktop-mac/Sources/DesktopApp/Screens/Detail/DetailScreenContainer.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/Screens/Detail/DetailScreenContainer.swift
@@ -27,8 +27,7 @@ final class DetailScreenContainer {
     private let groupDocumentProvider: (String, String) async -> DocumentTab?
     private let fallbackRowProvider: (String) -> SourceRow?
     private let toastPresenter: (ToastStyle, String) -> Void
-    private let hasInspectPayloadProvider: (String) -> Bool
-    private let isInspectRequestInFlightProvider: (String) -> Bool
+    private let shouldInspectDetailProvider: (String) -> Bool
     private let isUpdatingCurrentGroupProvider: () -> Bool
     private let selectSourceAction: (String) async -> Void
     private let updateCurrentGroupAction: () async -> Void
@@ -62,8 +61,7 @@ final class DetailScreenContainer {
         groupDocument: @escaping (String, String) async -> DocumentTab? = { _, _ in nil },
         fallbackRow: @escaping (String) -> SourceRow? = { _ in nil },
         toastPresenter: @escaping (ToastStyle, String) -> Void = { _, _ in },
-        hasInspectPayload: @escaping (String) -> Bool = { _ in false },
-        isInspectRequestInFlight: @escaping (String) -> Bool = { _ in false },
+        shouldInspectDetail: @escaping (String) -> Bool = { _ in false },
         isUpdatingCurrentGroup: @escaping () -> Bool = { false },
         selectSource: @escaping (String) async -> Void = { _ in },
         updateCurrentGroup: @escaping () async -> Void = {},
@@ -79,8 +77,7 @@ final class DetailScreenContainer {
         self.groupDocumentProvider = groupDocument
         self.fallbackRowProvider = fallbackRow
         self.toastPresenter = toastPresenter
-        self.hasInspectPayloadProvider = hasInspectPayload
-        self.isInspectRequestInFlightProvider = isInspectRequestInFlight
+        self.shouldInspectDetailProvider = shouldInspectDetail
         self.isUpdatingCurrentGroupProvider = isUpdatingCurrentGroup
         self.selectSourceAction = selectSource
         self.updateCurrentGroupAction = updateCurrentGroup
@@ -97,8 +94,7 @@ final class DetailScreenContainer {
         groupDocument: @escaping (String, String) async -> DocumentTab? = { _, _ in nil },
         fallbackRow: @escaping (String) -> SourceRow? = { _ in nil },
         toastPresenter: @escaping (ToastStyle, String) -> Void = { _, _ in },
-        hasInspectPayload: @escaping (String) -> Bool = { _ in false },
-        isInspectRequestInFlight: @escaping (String) -> Bool = { _ in false },
+        shouldInspectDetail: @escaping (String) -> Bool = { _ in false },
         isUpdatingCurrentGroup: @escaping () -> Bool = { false },
         selectSource: @escaping (String) async -> Void = { _ in },
         updateCurrentGroup: @escaping () async -> Void = {},
@@ -115,8 +111,7 @@ final class DetailScreenContainer {
             groupDocument: groupDocument,
             fallbackRow: fallbackRow,
             toastPresenter: toastPresenter,
-            hasInspectPayload: hasInspectPayload,
-            isInspectRequestInFlight: isInspectRequestInFlight,
+            shouldInspectDetail: shouldInspectDetail,
             isUpdatingCurrentGroup: isUpdatingCurrentGroup,
             selectSource: selectSource,
             updateCurrentGroup: updateCurrentGroup,
@@ -145,12 +140,9 @@ final class DetailScreenContainer {
         isUpdatingCurrentGroupProvider()
     }
 
-    func hasInspectPayload(for sourceId: String) -> Bool {
-        hasInspectPayloadProvider(sourceId)
-    }
-
-    func isInspectRequestInFlight(for sourceId: String) -> Bool {
-        isInspectRequestInFlightProvider(sourceId)
+    var detailRevision: String? {
+        guard let sourceId else { return nil }
+        return detailSnapshot(sourceId)?.revision
     }
 
     var viewModel: DetailViewModel? {
@@ -254,6 +246,20 @@ final class DetailScreenContainer {
 
     func selectSource(_ sourceId: String) async {
         await selectSourceAction(sourceId)
+    }
+
+    func enterDetail(sourceId: String) async {
+        guard self.sourceId == sourceId else { return }
+        reconcileDetailSelection(sourceId: sourceId)
+        guard shouldInspectDetailProvider(sourceId) else { return }
+        await selectSourceAction(sourceId)
+        guard self.sourceId == sourceId else { return }
+        reconcileDetailSelection(sourceId: sourceId)
+    }
+
+    func reconcileDetailSelection(sourceId: String) {
+        guard self.sourceId == sourceId else { return }
+        DetailRouteBootstrap.applySelections(state: screenState, sourceId: sourceId, detail: viewModel)
     }
 
     func updateCurrentGroup() async {

--- a/apps/desktop-mac/Sources/DesktopApp/ViewModels/MainViewModel.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/ViewModels/MainViewModel.swift
@@ -4,9 +4,31 @@ import Observation
 @MainActor
 @Observable
 final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
-    struct ScopedSourceKey: Hashable {
+    private struct ScopedSourceKey: Hashable {
         let scope: ProjectScopeSelection
         let sourceId: String
+    }
+
+    private enum DetailFreshness: Equatable {
+        case absent
+        case fresh
+        case refreshRequired
+    }
+
+    private enum DetailProjectionError: LocalizedError {
+        case invalidInspectPayload(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidInspectPayload(let sourceId):
+                return "Inspect returned an invalid payload for \(sourceId)"
+            }
+        }
+    }
+
+    private struct DetailProjection {
+        var payload: [String: Any]?
+        var freshness: DetailFreshness
     }
 
     enum Page: Equatable {
@@ -46,7 +68,7 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
     private let legacyPinnedSourceIdsKey = "desktop.pinnedSourceIds"
     private let pinnedSourceIdsMigrationKey = "desktop.pinnedSourceIds.migratedToRuntimePreferences"
     private var detectedTargets: Set<String> = []
-    var inspectedPayloadBySourceId: [ScopedSourceKey: [String: Any]] = [:]
+    private var detailProjectionBySource: [ScopedSourceKey: DetailProjection] = [:]
     private var detailEnrichmentPayloadBySourceId: [String: [String: Any]] = [:]
     @ObservationIgnored private var detailEnrichmentTasksBySourceId: [String: Task<Void, Never>] = [:]
     @ObservationIgnored private var detailEnrichmentTokensBySourceId: [String: UInt64] = [:]
@@ -284,8 +306,26 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
     }
 
     func updateSourceIds(_ ids: [String]) {
+        let allowedSourceIds = Set(ids)
+        let ownedDetailSourceIds = Set(detailProjectionBySource.keys.map(\.sourceId))
+            .union(detailEnrichmentPayloadBySourceId.keys)
+            .union(detailEnrichmentTasksBySourceId.keys)
+        let removedSourceIds = ownedDetailSourceIds.subtracting(allowedSourceIds)
+        for sourceId in removedSourceIds {
+            removeDetailState(for: sourceId)
+        }
         stateManager.sourceIds = ids
         importLogic.updateAllSummaries(sourceManagement.summaries())
+    }
+
+    private func removeDetailState(for sourceId: String) {
+        detailProjectionBySource = detailProjectionBySource.filter { $0.key.sourceId != sourceId }
+        sourceManagement.invalidateInspectState(for: sourceId)
+        invalidateDetailEnrichmentRequest(sourceId: sourceId)
+        detailEnrichmentPayloadBySourceId.removeValue(forKey: sourceId)
+        detailEnrichmentTokensBySourceId.removeValue(forKey: sourceId)
+        refreshedDetailEnrichmentSourceIds.remove(sourceId)
+        detailLogic.invalidatePreparedDetailContent(for: sourceId)
     }
 
     func selectSource(_ sourceId: String) {
@@ -1033,17 +1073,20 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
 
     func selectSource(_ sourceId: String) async {
         stateManager.selectSource(sourceId)
+        let scope = currentProjectScope()
         do {
-            let response = try await sourceManagement.selectSource(sourceId, scope: currentProjectScope())
-            if let payload = response.data?.value as? [String: Any] {
-                if let key = scopedSourceKey(sourceId: sourceId, scope: currentProjectScope()) {
-                    inspectedPayloadBySourceId[key] = payload
-                }
+            let outcome = try await sourceManagement.inspectSource(sourceId, scope: scope, intent: .navigation)
+            guard case .current(let response) = outcome else { return }
+            if let payload = validInspectPayload(from: response, sourceId: sourceId),
+               let key = scopedSourceKey(sourceId: sourceId, scope: scope) {
+                detailProjectionBySource[key] = DetailProjection(payload: payload, freshness: .fresh)
                 detailLogic.invalidatePreparedDetailContent(for: sourceId)
                 let isAwaitingEnrichment = scheduleDetailEnrichmentFetch(sourceId: sourceId)
                 if !isAwaitingEnrichment {
                     scheduleActiveDetailWarmupIfNeeded(sourceId: sourceId)
                 }
+            } else {
+                throw DetailProjectionError.invalidInspectPayload(sourceId)
             }
             stateManager.setLatestWarnings(response.warnings)
         } catch {
@@ -1095,29 +1138,125 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
     }
 
     private func performQueuedUpdate(sourceId: String) async {
+        let operationScope = currentProjectScope()
         do {
             let response = try await sourceManagement.updateSelectedSource(sourceId)
             if let response {
-                await synchronizeAfterMutation(response)
+                await synchronizeAfterUpdateMutation(response)
             } else {
-                await synchronizeState(refreshDoctor: true)
+                await synchronizeAfterNoOpUpdate()
             }
             registerRecentlyUpdatedSources(from: response?.data?.value)
-            showToast(style: .success, text: .plain(updateSummaryMessage(from: response?.data?.value, fallbackCount: 1)))
+            let refreshOutcome = await refreshActiveDetailAfterCommittedUpdate(
+                affectedSourceIds: [sourceId],
+                operationScope: operationScope
+            )
+            if refreshOutcome == .refreshFailed {
+                showToast(style: .neutral, text: localizedText("toast.update.detail_refresh_failed"))
+            } else {
+                showToast(style: .success, text: .plain(updateSummaryMessage(from: response?.data?.value, fallbackCount: 1)))
+            }
         } catch {
             showOperationFailureToast(fallbackKey: "toast.update.failed", fallbackArgument: error.localizedDescription, error: error)
         }
     }
 
+    private enum PostCommitDetailRefreshOutcome: Equatable {
+        case notApplicable
+        case refreshed
+        case refreshFailed
+    }
+
+    private func refreshActiveDetailAfterCommittedUpdate(
+        affectedSourceIds: Set<String>,
+        operationScope: ProjectScopeSelection
+    ) async -> PostCommitDetailRefreshOutcome {
+        guard currentProjectScope() == operationScope,
+              case .detail(let sourceId) = currentRoute,
+              affectedSourceIds.contains(sourceId),
+              let key = scopedSourceKey(sourceId: sourceId, scope: operationScope) else {
+            return .notApplicable
+        }
+
+        let retainedPayload = detailProjectionBySource[key]?.payload
+        detailProjectionBySource[key] = DetailProjection(
+            payload: retainedPayload,
+            freshness: .refreshRequired
+        )
+
+        do {
+            let outcome = try await sourceManagement.inspectSource(sourceId, scope: operationScope, intent: .postCommit)
+            guard case .current(let response) = outcome else {
+                return .notApplicable
+            }
+            guard currentProjectScope() == operationScope,
+                  case .detail(let activeSourceId) = currentRoute,
+                  activeSourceId == sourceId else {
+                return .notApplicable
+            }
+            guard let payload = validInspectPayload(from: response, sourceId: sourceId) else {
+                throw DetailProjectionError.invalidInspectPayload(sourceId)
+            }
+
+            detailProjectionBySource[key] = DetailProjection(payload: payload, freshness: .fresh)
+            detailLogic.invalidatePreparedDetailContent(for: sourceId)
+            scheduleActiveDetailWarmupIfNeeded(sourceId: sourceId)
+            stateManager.setLatestWarnings(response.warnings)
+            return .refreshed
+        } catch {
+            guard currentProjectScope() == operationScope,
+                  case .detail(let activeSourceId) = currentRoute,
+                  activeSourceId == sourceId else {
+                return .notApplicable
+            }
+            return .refreshFailed
+        }
+    }
+
     private func performQueuedBulkUpdate(sourceIds: [String]) async {
+        let operationScope = currentProjectScope()
         do {
             let response = try await sourceManagement.updateSourcesReturningResponse(sourceIds)
-            await synchronizeAfterMutation(response)
+            await synchronizeAfterUpdateMutation(response)
             registerRecentlyUpdatedSources(from: response.data?.value)
-            presentBulkUpdateOutcome(requestedCount: sourceIds.count, payload: response.data?.value, warnings: response.warnings)
+            let committedSourceIds = committedSourceIds(from: response.data?.value)
+            let refreshOutcome = await refreshActiveDetailAfterCommittedUpdate(
+                affectedSourceIds: committedSourceIds,
+                operationScope: operationScope
+            )
+            if refreshOutcome == .refreshFailed {
+                let mutationOutcome = Self.parseBulkUpdateOutcome(
+                    requestedCount: sourceIds.count,
+                    payload: response.data?.value,
+                    warnings: response.warnings
+                )
+                if mutationOutcome.failedCount > 0 {
+                    showToast(
+                        style: .neutral,
+                        text: localizedText(
+                            "toast.update.partial_detail_refresh_failed",
+                            String(mutationOutcome.successCount),
+                            String(mutationOutcome.failedCount),
+                            mutationOutcome.firstFailureMessage ?? localized("toast.update.failed", "update failed")
+                        )
+                    )
+                } else {
+                    showToast(style: .neutral, text: localizedText("toast.update.detail_refresh_failed"))
+                }
+            } else {
+                presentBulkUpdateOutcome(requestedCount: sourceIds.count, payload: response.data?.value, warnings: response.warnings)
+            }
         } catch {
             showOperationFailureToast(fallbackKey: "toast.update.failed", fallbackArgument: error.localizedDescription, error: error)
         }
+    }
+
+    private func committedSourceIds(from payload: Any?) -> Set<String> {
+        guard let data = payload as? [String: Any],
+              let updated = data["updated"] as? [[String: Any]] else {
+            return []
+        }
+        return Set(updated.compactMap { ($0["sourceId"] as? String)?.nonEmpty })
     }
 
     var importDisplayGroups: [ImportGroupItem] {
@@ -1228,6 +1367,7 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
     func deleteSource(sourceId: String) async {
         do {
             try await sourceManagement.deleteSource(sourceId: sourceId)
+            removeDetailState(for: sourceId)
             if selectedSourceId == sourceId { stateManager.selectSource(nil) }
             await synchronizeState(refreshDoctor: true)
             if let first = sourceIds.first {
@@ -1329,12 +1469,23 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
         return await detailLogic.groupDocument(for: sourceId, documentId: documentId, input: input)
     }
 
-    func hasInspectPayload(for sourceId: String) -> Bool {
-        sourceManagement.hasInspectPayload(for: sourceId, scope: currentProjectScope())
+    func hasFreshDetailProjection(for sourceId: String) -> Bool {
+        guard let key = scopedSourceKey(sourceId: sourceId, scope: currentProjectScope()) else {
+            return false
+        }
+        return detailFreshness(for: key) == .fresh
     }
 
     func isInspectRequestInFlight(for sourceId: String) -> Bool {
         sourceManagement.isInspectRequestInFlight(for: sourceId, scope: currentProjectScope())
+    }
+
+    func shouldInspectDetail(for sourceId: String) -> Bool {
+        !hasFreshDetailProjection(for: sourceId) && !isInspectRequestInFlight(for: sourceId)
+    }
+
+    private func detailFreshness(for key: ScopedSourceKey) -> DetailFreshness {
+        detailProjectionBySource[key]?.freshness ?? .absent
     }
 
     func bindRouteState(_ state: DesktopAppState) {
@@ -1459,17 +1610,9 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
     }
 
     private func updateCachedDetailDisplayName(sourceId: String, displayName: String, originalDisplayName: String) {
-        if let payload = detailEnrichmentPayloadBySourceId[sourceId] {
-            detailEnrichmentPayloadBySourceId[sourceId] = enrichmentPayloadWithDisplayName(
-                payload,
-                displayName: displayName,
-                originalDisplayName: originalDisplayName
-            )
-        }
-
-        for key in inspectedPayloadBySourceId.keys where key.sourceId == sourceId {
-            if let payload = inspectedPayloadBySourceId[key] {
-                inspectedPayloadBySourceId[key] = enrichmentPayloadWithDisplayName(
+        for key in detailProjectionBySource.keys where key.sourceId == sourceId {
+            if let payload = detailProjectionBySource[key]?.payload {
+                detailProjectionBySource[key]?.payload = enrichmentPayloadWithDisplayName(
                     payload,
                     displayName: displayName,
                     originalDisplayName: originalDisplayName
@@ -1486,7 +1629,7 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
 
     func currentProjectScope() -> ProjectScopeSelection { selectedProjectScope }
 
-    func scopedSourceKey(sourceId: String, scope: ProjectScopeSelection? = nil) -> ScopedSourceKey? {
+    private func scopedSourceKey(sourceId: String, scope: ProjectScopeSelection? = nil) -> ScopedSourceKey? {
         let trimmed = sourceId.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         return ScopedSourceKey(scope: scope ?? currentProjectScope(), sourceId: trimmed)
@@ -1543,7 +1686,7 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
             }
             let mergedPayload = DetailPayloadOverlay.merge(
                 detailEnrichmentPayloadBySourceId[sourceId] ?? [:],
-                with: payload
+                with: cachedGroupCardEnrichmentPayload(payload)
             )
             if !mergedPayload.isEmpty {
                 detailEnrichmentPayloadBySourceId[sourceId] = mergedPayload
@@ -1702,6 +1845,28 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
         }
     }
 
+    private func synchronizeAfterUpdateMutation(_ response: BridgeResponse) async {
+        guard sourceManagement.applyUpdateWorkspace(response.data?.value) else {
+            await synchronizeAfterNoOpUpdate()
+            return
+        }
+        detectedTargets = sourceManagement.detectedTargetIds()
+        stateManager.setLatestWarnings(response.warnings)
+        stateManager.setHealthStatus(response.warnings.isEmpty ? .healthy : .warnings)
+    }
+
+    private func synchronizeAfterNoOpUpdate() async {
+        do {
+            let response = try await sourceManagement.refreshListAfterUpdate()
+            detectedTargets = sourceManagement.detectedTargetIds()
+            stateManager.setLatestWarnings(response.warnings)
+            stateManager.setHealthStatus(response.warnings.isEmpty ? .healthy : .warnings)
+        } catch {
+            stateManager.setHealthStatus(.error)
+        }
+        await runDoctor()
+    }
+
     func localizedText(_ key: String, _ arguments: [String]) -> PresentationText {
         if arguments.isEmpty {
             return .localized(key)
@@ -1711,6 +1876,9 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
 
     @discardableResult
     private func scheduleDetailEnrichmentFetch(sourceId: String, force: Bool = false) -> Bool {
+        let projectionKey = scopedSourceKey(sourceId: sourceId, scope: currentProjectScope()).flatMap { key in
+            detailProjectionBySource[key] == nil ? nil : key
+        }
         if !force {
             if refreshedDetailEnrichmentSourceIds.contains(sourceId) {
                 return false
@@ -1738,42 +1906,68 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
             do {
                 let response = try await self.detailEnrichmentQuery.inspectEnrichment(sourceId: sourceId)
                 guard !Task.isCancelled,
-                      self.detailEnrichmentTokensBySourceId[sourceId] == token else {
+                      self.detailEnrichmentTokensBySourceId[sourceId] == token,
+                      self.isEnrichmentIdentityCurrent(sourceId: sourceId, projectionKey: projectionKey) else {
                     return
                 }
                 if let payload = response.data?.value as? [String: Any] {
-                    let displayName = self.renamedSourceDisplayNameOverridesBySourceId[sourceId]
-                        ?? self.sourceManagement.summary(for: sourceId)?.sourceDisplayName
-                    let originalDisplayName = self.renamedSourceOriginalDisplayNameOverridesBySourceId[sourceId]
-                        ?? self.sourceManagement.summary(for: sourceId)?.sourceOriginalDisplayName
-                        ?? displayName
-                    let normalizedPayload: [String: Any]
-                    if let displayName, let originalDisplayName {
-                        normalizedPayload = self.enrichmentPayloadWithDisplayName(
-                            payload,
-                            displayName: displayName,
-                            originalDisplayName: originalDisplayName
-                        )
-                    } else {
-                        normalizedPayload = payload
-                    }
+                    let normalizedPayload = self.metadataOnlyEnrichmentPayload(payload)
                     self.detailEnrichmentPayloadBySourceId[sourceId] = DetailPayloadOverlay.merge(
                         self.detailEnrichmentPayloadBySourceId[sourceId] ?? [:],
                         with: normalizedPayload
                     )
-                    if self.isActiveDetailSource(sourceId) {
-                        self.detailLogic.invalidatePreparedDetailContent(for: sourceId)
-                    }
                 }
                 self.refreshedDetailEnrichmentSourceIds.insert(sourceId)
                 self.stateManager.setLatestWarnings(response.warnings)
                 self.scheduleActiveDetailWarmupIfNeeded(sourceId: sourceId)
             } catch {
+                guard !Task.isCancelled,
+                      self.detailEnrichmentTokensBySourceId[sourceId] == token,
+                      self.isEnrichmentIdentityCurrent(sourceId: sourceId, projectionKey: projectionKey) else {
+                    return
+                }
                 self.scheduleActiveDetailWarmupIfNeeded(sourceId: sourceId)
             }
         }
         detailEnrichmentTasksBySourceId[sourceId] = task
         return true
+    }
+
+    private func invalidateDetailEnrichmentRequest(sourceId: String) {
+        detailEnrichmentTasksBySourceId[sourceId]?.cancel()
+        detailEnrichmentTasksBySourceId.removeValue(forKey: sourceId)
+        detailEnrichmentTokenSeed &+= 1
+        detailEnrichmentTokensBySourceId[sourceId] = detailEnrichmentTokenSeed
+    }
+
+    private func metadataOnlyEnrichmentPayload(_ payload: [String: Any]) -> [String: Any] {
+        let allowedKeys = ["sourceMetadata", "sourceSnapshot"]
+        return allowedKeys.reduce(into: [:]) { result, key in
+            if let value = payload[key] {
+                result[key] = value
+            }
+        }
+    }
+
+    private func cachedGroupCardEnrichmentPayload(_ payload: [String: Any]) -> [String: Any] {
+        var normalized = metadataOnlyEnrichmentPayload(payload)
+        if let groupPath = (payload["groupPath"] as? String)?.nonEmpty {
+            normalized["groupPath"] = groupPath
+        }
+        return normalized
+    }
+
+    private func isEnrichmentIdentityCurrent(
+        sourceId: String,
+        projectionKey: ScopedSourceKey?
+    ) -> Bool {
+        guard sourceIds.contains(sourceId) else { return false }
+        guard let projectionKey else { return true }
+        guard currentProjectScope() == projectionKey.scope,
+              let projectionPayload = detailProjectionBySource[projectionKey]?.payload else {
+            return false
+        }
+        return inspectPayloadSourceId(projectionPayload) == sourceId
     }
 
     private func scheduleActiveDetailWarmupIfNeeded(sourceId: String) {
@@ -1859,9 +2053,31 @@ final class MainViewModel: SourceManagementDelegate, ImportLogicDelegate {
     }
 
     private func mergedDetailPayload(for sourceId: String) -> [String: Any] {
-        let payload = inspectedPayloadBySourceId[ScopedSourceKey(scope: currentProjectScope(), sourceId: sourceId)] ?? [:]
-        let enrichmentPayload = detailEnrichmentPayloadBySourceId[sourceId] ?? [:]
+        let payload = detailProjectionBySource[
+            ScopedSourceKey(scope: currentProjectScope(), sourceId: sourceId)
+        ]?.payload ?? [:]
+        let enrichmentPayload = metadataOnlyEnrichmentPayload(detailEnrichmentPayloadBySourceId[sourceId] ?? [:])
         return DetailPayloadOverlay.merge(payload, with: enrichmentPayload)
+    }
+
+    private func validInspectPayload(from response: BridgeResponse, sourceId: String) -> [String: Any]? {
+        guard let payload = response.data?.value as? [String: Any],
+              let source = payload["source"] as? [String: Any],
+              inspectPayloadSourceId(payload) == sourceId,
+              payload["summary"] is [String: Any],
+              payload["binding"] is [String: Any],
+              payload["leafs"] is [[String: Any]],
+              source["displayName"] is String,
+              source["kind"] is String,
+              source["locator"] is String else {
+            return nil
+        }
+        return payload
+    }
+
+    private func inspectPayloadSourceId(_ payload: [String: Any]) -> String? {
+        let source = payload["source"] as? [String: Any]
+        return (source?["id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
     }
 
     private func updateSummaryMessage(from value: Any?, fallbackCount: Int) -> String {

--- a/apps/desktop-mac/Sources/DesktopApp/ViewModels/SourceManagement.swift
+++ b/apps/desktop-mac/Sources/DesktopApp/ViewModels/SourceManagement.swift
@@ -14,6 +14,16 @@ final class SourceManagement {
         var enabledTargets: [String]
     }
 
+    enum InspectIntent: Equatable {
+        case navigation
+        case postCommit
+    }
+
+    enum InspectOutcome {
+        case current(BridgeResponse)
+        case superseded
+    }
+
     struct WorkflowSummary: Sendable {
         enum SelectionMode: String, Sendable {
             case all
@@ -114,7 +124,6 @@ final class SourceManagement {
     private var allSummaries: [WorkflowSummary] = []
     private var workingDrafts: [ScopedSourceKey: DraftState] = [:]
     private var detectedTargets: Set<String> = []
-    private var inspectedPayloadBySourceId: [ScopedSourceKey: [String: Any]] = [:]
     private var saveStateBySourceId: [ScopedSourceKey: SaveState] = [:]
     private var recentlyUpdatedSourceKeys: Set<ScopedSourceKey> = []
     private var renamedSourceDisplayNameOverridesBySourceId: [String: String] = [:]
@@ -222,19 +231,20 @@ final class SourceManagement {
         scheduleRecentlyUpdatedIndicatorClear(for: key)
     }
 
-    func hasInspectPayload(for sourceId: String, scope: ProjectScopeSelection) -> Bool {
-        let key = ScopedSourceKey(scope: scope, sourceId: sourceId)
-        return inspectedPayloadBySourceId[key] != nil
-    }
-
     func isInspectRequestInFlight(for sourceId: String, scope: ProjectScopeSelection) -> Bool {
         let key = ScopedSourceKey(scope: scope, sourceId: sourceId)
         return inspectRequestTasksBySourceId[key] != nil
     }
 
-    func inspectedPayload(for sourceId: String, scope: ProjectScopeSelection) -> [String: Any]? {
-        let key = ScopedSourceKey(scope: scope, sourceId: sourceId)
-        return inspectedPayloadBySourceId[key]
+    func invalidateInspectState(for sourceId: String) {
+        let keys = Set(inspectRequestTasksBySourceId.keys)
+            .union(inspectRequestTokensBySourceId.keys)
+            .filter { $0.sourceId == sourceId }
+        for key in keys {
+            inspectRequestTasksBySourceId[key]?.cancel()
+            inspectRequestTasksBySourceId.removeValue(forKey: key)
+            inspectRequestTokensBySourceId.removeValue(forKey: key)
+        }
     }
 
     func bootstrap() async throws -> [BridgeIssue] {
@@ -256,19 +266,37 @@ final class SourceManagement {
         return true
     }
 
+    @discardableResult
+    func applyUpdateWorkspace(_ value: Any?) -> Bool {
+        guard
+            let data = value as? [String: Any],
+            let workspace = data["workspace"] as? [String: Any],
+            workspace["summaries"] is [[String: Any]]
+        else {
+            return false
+        }
+        parseWorkspaceState(workspace)
+        return true
+    }
+
     func refreshList() async throws -> BridgeResponse {
         let response = try await fetchListResponse()
         applyList(response)
         return response
     }
 
-    func selectSource(_ sourceId: String, scope: ProjectScopeSelection) async throws -> BridgeResponse {
-        let response = try await fetchInspectResponse(sourceId: sourceId, scope: scope)
-        if let payload = response.data?.value as? [String: Any] {
-            let key = ScopedSourceKey(scope: scope, sourceId: sourceId)
-            inspectedPayloadBySourceId[key] = payload
-        }
+    func refreshListAfterUpdate() async throws -> BridgeResponse {
+        let response = try await fetchListResponse()
+        applyUpdateList(response)
         return response
+    }
+
+    func inspectSource(
+        _ sourceId: String,
+        scope: ProjectScopeSelection,
+        intent: InspectIntent
+    ) async throws -> InspectOutcome {
+        try await fetchInspectResponse(sourceId: sourceId, scope: scope, intent: intent)
     }
 
     func runDoctor() async throws -> ([DoctorIssueRow], [BridgeIssue]) {
@@ -371,7 +399,15 @@ final class SourceManagement {
     func pruneStateMaps(allowedSourceIds: Set<String>) {
         workingDrafts = workingDrafts.filter { allowedSourceIds.contains($0.key.sourceId) }
         saveStateBySourceId = saveStateBySourceId.filter { allowedSourceIds.contains($0.key.sourceId) }
-        inspectedPayloadBySourceId = inspectedPayloadBySourceId.filter { allowedSourceIds.contains($0.key.sourceId) }
+
+        let removedInspectSourceIds = Set(
+            inspectRequestTasksBySourceId.keys
+                .map(\.sourceId)
+                .filter { !allowedSourceIds.contains($0) }
+        )
+        for sourceId in removedInspectSourceIds {
+            invalidateInspectState(for: sourceId)
+        }
 
         let removedRecentlyUpdatedKeys = Set(
             recentlyUpdatedSourceKeys.filter { !allowedSourceIds.contains($0.sourceId) }
@@ -484,8 +520,8 @@ final class SourceManagement {
     }
 
     private func removeStateForSource(_ sourceId: String) {
+        invalidateInspectState(for: sourceId)
         workingDrafts = workingDrafts.filter { $0.key.sourceId != sourceId }
-        inspectedPayloadBySourceId = inspectedPayloadBySourceId.filter { $0.key.sourceId != sourceId }
         saveStateBySourceId = saveStateBySourceId.filter { $0.key.sourceId != sourceId }
     }
 
@@ -536,13 +572,17 @@ final class SourceManagement {
     }
 
     private func parseBootstrapData(_ value: Any?) {
+        parseWorkspaceState(value)
+        guard let data = value as? [String: Any] else { return }
+        delegate?.applyProjectScopeState(data)
+    }
+
+    private func parseWorkspaceState(_ value: Any?) {
         guard let data = value as? [String: Any] else { return }
 
         delegate?.applyCachedGroupCardEnrichment(data)
         applyPinnedSourceIds(data)
         applySummaries(parseSummariesPayload(data))
-        delegate?.applyProjectScopeState(data)
-
         if let availableTargets = data["availableTargets"] as? [String] {
             detectedTargets.formUnion(availableTargets)
         }
@@ -574,10 +614,20 @@ final class SourceManagement {
     }
 
     private func applyList(_ response: BridgeResponse) {
+        applyListState(response)
+        if let data = response.data?.value as? [String: Any] {
+            delegate?.applyProjectScopeState(data)
+        }
+    }
+
+    private func applyUpdateList(_ response: BridgeResponse) {
+        applyListState(response)
+    }
+
+    private func applyListState(_ response: BridgeResponse) {
         let summaries = parseSummariesPayload(response.data?.value)
         if let data = response.data?.value as? [String: Any] {
             delegate?.applyCachedGroupCardEnrichment(data)
-            delegate?.applyProjectScopeState(data)
             if let availableTargets = data["availableTargets"] as? [String] {
                 detectedTargets = Set(availableTargets)
                 for summary in summaries {
@@ -679,10 +729,16 @@ final class SourceManagement {
         }
     }
 
-    private func fetchInspectResponse(sourceId: String, scope: ProjectScopeSelection) async throws -> BridgeResponse {
+    private func fetchInspectResponse(
+        sourceId: String,
+        scope: ProjectScopeSelection,
+        intent: InspectIntent
+    ) async throws -> InspectOutcome {
         let key = ScopedSourceKey(scope: scope, sourceId: sourceId)
-        if let existingTask = inspectRequestTasksBySourceId[key] {
-            return try await existingTask.value
+        if intent == .navigation,
+           let existingTask = inspectRequestTasksBySourceId[key],
+           let token = inspectRequestTokensBySourceId[key] {
+            return try await inspectOutcome(for: existingTask, key: key, token: token)
         }
 
         inspectRequestTokenSeed &+= 1
@@ -691,18 +747,28 @@ final class SourceManagement {
         inspectRequestTasksBySourceId[key] = task
         inspectRequestTokensBySourceId[key] = token
 
+        return try await inspectOutcome(for: task, key: key, token: token)
+    }
+
+    private func inspectOutcome(
+        for task: Task<BridgeResponse, Error>,
+        key: ScopedSourceKey,
+        token: UInt64
+    ) async throws -> InspectOutcome {
         do {
             let response = try await task.value
-            if inspectRequestTokensBySourceId[key] == token {
-                inspectRequestTasksBySourceId.removeValue(forKey: key)
-                inspectRequestTokensBySourceId.removeValue(forKey: key)
+            guard inspectRequestTokensBySourceId[key] == token else {
+                return .superseded
             }
-            return response
+            inspectRequestTasksBySourceId.removeValue(forKey: key)
+            inspectRequestTokensBySourceId.removeValue(forKey: key)
+            return .current(response)
         } catch {
-            if inspectRequestTokensBySourceId[key] == token {
-                inspectRequestTasksBySourceId.removeValue(forKey: key)
-                inspectRequestTokensBySourceId.removeValue(forKey: key)
+            guard inspectRequestTokensBySourceId[key] == token else {
+                return .superseded
             }
+            inspectRequestTasksBySourceId.removeValue(forKey: key)
+            inspectRequestTokensBySourceId.removeValue(forKey: key)
             throw error
         }
     }

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/DetailLoadingLayoutTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/DetailLoadingLayoutTests.swift
@@ -403,12 +403,6 @@ final class DetailLoadingLayoutTests: XCTestCase {
         XCTAssertNil(state.detailSelectedTreeItemIdByGroup["alpha"])
     }
 
-    func testDetailRouteBootstrapOnlyFetchesInspectWhenPayloadIsMissing() {
-        XCTAssertTrue(DetailRouteBootstrap.shouldFetchInspect(hasInspectPayload: false, isInspectRequestInFlight: false))
-        XCTAssertFalse(DetailRouteBootstrap.shouldFetchInspect(hasInspectPayload: true, isInspectRequestInFlight: false))
-        XCTAssertFalse(DetailRouteBootstrap.shouldFetchInspect(hasInspectPayload: false, isInspectRequestInFlight: true))
-    }
-
     func testDetailWordCountCountsWhitespaceSeparatedWords() {
         XCTAssertEqual(DetailInfoLayout.wordCount(from: "# Title\n\none two  three"), 4)
         XCTAssertNil(DetailInfoLayout.wordCount(from: "   "))

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/DetailScreenContainerTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/DetailScreenContainerTests.swift
@@ -4,6 +4,131 @@ import XCTest
 
 @MainActor
 final class DetailScreenContainerTests: XCTestCase {
+    func testEnterDetailUsesRealEntryFlowToInspectAndApplyFreshSelections() async {
+        let state = DesktopAppState()
+        state.view.currentRoute = .detail(sourceId: "alpha")
+        var shouldInspect = true
+        var inspectCount = 0
+        var snapshot: DetailViewModel.Snapshot?
+
+        let container = DetailScreenContainer(
+            state: state,
+            detailSnapshot: { _ in snapshot },
+            shouldInspectDetail: { _ in shouldInspect },
+            selectSource: { _ in
+                inspectCount += 1
+                shouldInspect = false
+                snapshot = .fixture(
+                    sourceId: "alpha",
+                    skills: [
+                        DetailSkill(
+                            id: "alpha-a",
+                            title: "Browse",
+                            summary: "Browse things.",
+                            version: nil,
+                            author: "Acme",
+                            originLabel: "local",
+                            starCount: nil,
+                            folderPath: "/skills/alpha-a",
+                            relativeFolderPath: "alpha-a",
+                            documents: [],
+                            detailLines: [],
+                            documentContent: "# Browse",
+                            isEnabled: true,
+                            warningCount: 0
+                        )
+                    ]
+                )
+            }
+        )
+
+        await container.enterDetail(sourceId: "alpha")
+
+        XCTAssertEqual(inspectCount, 1)
+        XCTAssertEqual(container.screenState.detailSkillIdByGroup["alpha"], "alpha-a")
+    }
+
+    func testEnterDetailReconcilesSelectionWhenAcceptedRevisionChanges() async {
+        let state = DesktopAppState()
+        state.view.currentRoute = .detail(sourceId: "alpha")
+        let remainingSkill = DetailSkill(
+            id: "alpha-a",
+            title: "Browse",
+            summary: "Browse things.",
+            version: nil,
+            author: "Acme",
+            originLabel: "local",
+            starCount: nil,
+            folderPath: nil,
+            relativeFolderPath: nil,
+            documents: [],
+            detailLines: [],
+            documentContent: "# Browse",
+            isEnabled: true,
+            warningCount: 0
+        )
+        var snapshot = DetailViewModel.Snapshot.fixture(
+            sourceId: "alpha",
+            revision: "rev-1",
+            skills: [remainingSkill]
+        )
+        let container = DetailScreenContainer(state: state, detailSnapshot: { _ in snapshot })
+        container.screenState.detailShowsGroupOverviewByGroup["alpha"] = false
+        container.screenState.detailSkillIdByGroup["alpha"] = "removed"
+
+        snapshot = .fixture(sourceId: "alpha", revision: "rev-2", skills: [remainingSkill])
+        await container.enterDetail(sourceId: "alpha")
+
+        XCTAssertEqual(container.detailRevision, "rev-2")
+        XCTAssertEqual(container.screenState.detailSkillIdByGroup["alpha"], "alpha-a")
+    }
+
+    func testApplySelectionsFallsBackWhenSelectedSkillWasRemoved() {
+        let state = DetailScreenState()
+        state.detailShowsGroupOverviewByGroup["alpha"] = false
+        state.detailSkillIdByGroup["alpha"] = "removed"
+        state.pendingDetailSkillIdByGroup["alpha"] = "removed"
+        let remainingSkill = DetailSkill(
+            id: "remaining",
+            title: "Remaining",
+            summary: "Still installed.",
+            version: nil,
+            author: "Acme",
+            originLabel: "local",
+            starCount: nil,
+            folderPath: nil,
+            relativeFolderPath: nil,
+            documents: [],
+            detailLines: [],
+            documentContent: "# Remaining",
+            isEnabled: true,
+            warningCount: 0
+        )
+        let detail = DetailViewModel(snapshot: .fixture(skills: [remainingSkill]))
+
+        DetailRouteBootstrap.applySelections(state: state, sourceId: "alpha", detail: detail)
+
+        XCTAssertEqual(state.detailSkillIdByGroup["alpha"], "remaining")
+        XCTAssertNil(state.pendingDetailSkillIdByGroup["alpha"])
+        XCTAssertEqual(state.detailShowsGroupOverviewByGroup["alpha"], false)
+    }
+
+    func testApplySelectionsReturnsToOverviewWhenEverySkillWasRemoved() {
+        let state = DetailScreenState()
+        state.detailShowsGroupOverviewByGroup["alpha"] = false
+        state.detailSkillIdByGroup["alpha"] = "removed"
+        state.pendingDetailSkillIdByGroup["alpha"] = "removed"
+        state.detailSelectedTreeItemIdByGroup["alpha"] = "skill:removed"
+        let detail = DetailViewModel(snapshot: .fixture(skills: []))
+
+        DetailRouteBootstrap.applySelections(state: state, sourceId: "alpha", detail: detail)
+
+        XCTAssertNil(state.detailSkillIdByGroup["alpha"])
+        XCTAssertNil(state.pendingDetailSkillIdByGroup["alpha"])
+        XCTAssertNil(state.detailSelectedTreeItemIdByGroup["alpha"])
+        XCTAssertEqual(state.detailShowsGroupOverviewByGroup["alpha"], true)
+    }
+
     func testBuildsDetailViewModelFromCurrentDetailRoute() {
         let state = DesktopAppState()
         state.view.currentRoute = .detail(sourceId: "alpha")
@@ -673,6 +798,7 @@ private extension DetailViewModel.Snapshot {
         updatedRelative: String = "Updated 1 day ago",
         fileTree: [FileTreeItem] = [],
         groupDocuments: [DocumentDescriptor] = [],
+        skills: [DetailSkill] = [],
         targets: [DetailTarget] = [
             DetailTarget(
                 id: "claude-code",
@@ -718,7 +844,7 @@ private extension DetailViewModel.Snapshot {
             fileTree: fileTree,
             groupDocuments: groupDocuments,
             targets: targets,
-            skills: []
+            skills: skills
         )
         return Self(
             sourceId: sourceId,
@@ -756,7 +882,7 @@ private extension DetailViewModel.Snapshot {
             fileTree: fileTree,
             groupDocuments: groupDocuments,
             targets: targets,
-            skills: []
+            skills: skills
         )
     }
 }

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/MainViewModelProjectScopeTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/MainViewModelProjectScopeTests.swift
@@ -473,9 +473,28 @@ private final class ProjectScopeQueryStub: DesktopQueryTransporting {
     }
 
     func inspect(sourceId: String, scope: ProjectScopeSelection) async throws -> BridgeResponse {
-        BridgeResponse.success(command: .inspect, payload: [
+        let selectedLeafIds = scope == .global ? ["alpha-a"] : ["alpha-b"]
+        let summary = summaryPayload(
+            sourceId: sourceId,
+            selectedLeafIds: selectedLeafIds,
+            enabledTargets: ["codex"]
+        )
+        return BridgeResponse.success(command: .inspect, payload: [
             "source": [
-                "id": sourceId
+                "id": sourceId,
+                "kind": "clawhub",
+                "displayName": "Alpha",
+                "locator": "https://example.com/\(sourceId)"
+            ],
+            "leafs": summary["leafs"] as Any,
+            "binding": [
+                "selectedLeafIds": selectedLeafIds,
+                "targets": [
+                    "codex": [
+                        "enabled": true,
+                        "leafIds": selectedLeafIds
+                    ]
+                ]
             ],
             "deployments": [
                 [
@@ -487,11 +506,7 @@ private final class ProjectScopeQueryStub: DesktopQueryTransporting {
                         : "/Users/test/src/repo-a/.agents/skills/review"
                 ]
             ],
-            "summary": summaryPayload(
-                sourceId: sourceId,
-                selectedLeafIds: scope == .global ? ["alpha-a"] : ["alpha-b"],
-                enabledTargets: ["codex"]
-            )
+            "summary": summary
         ])
     }
 

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/MainViewModelSelectionTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/MainViewModelSelectionTests.swift
@@ -625,6 +625,731 @@ final class MainViewModelSelectionTests: XCTestCase {
         XCTAssertEqual(model.detailSnapshot(for: "alpha")?.enabledTargetCount, 0)
     }
 
+    func testUpdateSourceRefreshesActiveDetailWithAddedSkillLocalContentMetricAndFileTree() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        state.updateResponseIncludesWorkspace = true
+        let addedSkill = TestFixture.LeafState(
+            id: "alpha-c",
+            linkName: "audit",
+            name: "audit",
+            description: "Short summary.",
+            metadataWarnings: []
+        )
+        var updatedAlpha = try XCTUnwrap(state.sources["alpha"])
+        updatedAlpha.updatedAt = "2026-03-27T00:00:00Z"
+        updatedAlpha.leafs.append(addedSkill)
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: true,
+                    addedLeafIds: [addedSkill.id],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: updatedAlpha
+            )
+        ]
+        try fixture.reset(state: state)
+
+        let addedSkillDocument = """
+        # Audit Kit
+
+        This full local document includes unmistakable body content.
+
+        ## Workflow
+
+        Inspect prepare publish verify.
+
+        ## Notes
+
+        Alpha beta gamma delta epsilon.
+        """
+        try fixture.writeSkillDocument(
+            sourceId: "alpha",
+            leafId: addedSkill.id,
+            content: addedSkillDocument
+        )
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+        try await fixture.waitForDetailHydration(model, sourceId: "alpha")
+
+        XCTAssertFalse(model.detailSnapshot(for: "alpha")?.skills.contains(where: { $0.id == addedSkill.id }) == true)
+
+        await model.updateSource("alpha")
+        try await fixture.waitForDetailHydration(model, sourceId: "alpha", timeoutNanoseconds: 3_000_000_000)
+
+        let detail = try XCTUnwrap(model.detailSnapshot(for: "alpha"))
+        let skill = try XCTUnwrap(detail.skills.first(where: { $0.id == addedSkill.id }))
+        XCTAssertEqual(skill.documentContent, addedSkillDocument)
+        XCTAssertEqual(DetailInfoLayout.wordCount(from: skill.documentContent), 21)
+        XCTAssertNotEqual(
+            DetailInfoLayout.wordCount(from: skill.documentContent),
+            DetailInfoLayout.wordCount(from: addedSkill.description)
+        )
+        XCTAssertTrue(
+            detail.fileTree.first?.children.contains(where: {
+                $0.title == addedSkill.id && $0.isSkillRoot && $0.skillId == addedSkill.id
+            }) == true
+        )
+        let requests = fixture.loggedRequests()
+        let updateIndex = try XCTUnwrap(requests.lastIndex(where: { $0.command == "update" }))
+        let postUpdateInspectIndex = try XCTUnwrap(requests.lastIndex(where: { $0.command == "inspect" }))
+        XCTAssertLessThan(updateIndex, postUpdateInspectIndex)
+    }
+
+    func testCommittedUpdateWithFailedDetailRefreshKeepsContentAndRetriesOnDetailReentry() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        let addedSkill = TestFixture.LeafState(
+            id: "alpha-c",
+            linkName: "audit",
+            name: "audit",
+            description: "Fresh audit skill.",
+            metadataWarnings: []
+        )
+        var updatedAlpha = try XCTUnwrap(state.sources["alpha"])
+        updatedAlpha.updatedAt = "2026-03-27T00:00:00Z"
+        updatedAlpha.leafs.append(addedSkill)
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: true,
+                    addedLeafIds: [addedSkill.id],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: updatedAlpha
+            )
+        ]
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+        try await fixture.waitForDetailHydration(model, sourceId: "alpha")
+        let lastUsableSkillIds = try XCTUnwrap(model.detailSnapshot(for: "alpha")?.skills.map(\.id))
+
+        var failingState = try fixture.readState()
+        failingState.inspectFailuresRemainingBySourceId = ["alpha": 1]
+        try fixture.writeState(failingState)
+
+        await model.updateSource("alpha")
+
+        XCTAssertEqual(model.toast?.style, .neutral)
+        XCTAssertEqual(model.detailSnapshot(for: "alpha")?.skills.map(\.id), lastUsableSkillIds)
+        XCTAssertFalse(model.hasFreshDetailProjection(for: "alpha"))
+
+        let detailContainer = DetailScreenContainer(
+            state: appState,
+            detailSnapshot: { [weak model] sourceId in model?.detailSnapshot(for: sourceId) },
+            shouldInspectDetail: { [weak model] sourceId in model?.shouldInspectDetail(for: sourceId) ?? false },
+            selectSource: { [weak model] sourceId in await model?.selectSource(sourceId) }
+        )
+        appState.view.currentRoute = .home
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        await detailContainer.enterDetail(sourceId: "alpha")
+        try await fixture.waitForDetailHydration(model, sourceId: "alpha", timeoutNanoseconds: 3_000_000_000)
+
+        XCTAssertTrue(model.hasFreshDetailProjection(for: "alpha"))
+        XCTAssertTrue(model.detailSnapshot(for: "alpha")?.skills.contains(where: { $0.id == addedSkill.id }) == true)
+    }
+
+    func testBulkUpdateRefreshesOnlyCommittedActiveDetail() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        var updatedAlpha = try XCTUnwrap(state.sources["alpha"])
+        updatedAlpha.leafs.append(
+            TestFixture.LeafState(
+                id: "alpha-c",
+                linkName: "audit",
+                name: "audit",
+                description: "Fresh audit skill.",
+                metadataWarnings: []
+            )
+        )
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: true,
+                    addedLeafIds: ["alpha-c"],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: updatedAlpha
+            )
+        ]
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+
+        await model.updateAllGroupsFromHome()
+
+        XCTAssertTrue(model.detailSnapshot(for: "alpha")?.skills.contains(where: { $0.id == "alpha-c" }) == true)
+        XCTAssertEqual(
+            fixture.loggedRequests().filter {
+                $0.command == "inspect" && $0.payload?["sourceId"]?.value as? String == "alpha"
+            }.count,
+            2
+        )
+        XCTAssertFalse(
+            fixture.loggedRequests().contains {
+                $0.command == "inspect" && $0.payload?["sourceId"]?.value as? String == "beta"
+            }
+        )
+    }
+
+    func testBulkPartialMutationAndDetailRefreshFailureRemainVisibleTogether() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        var updatedAlpha = try XCTUnwrap(state.sources["alpha"])
+        updatedAlpha.updatedAt = "2026-03-27T00:00:00Z"
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: true,
+                    addedLeafIds: [],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: updatedAlpha
+            )
+        ]
+        state.updateFailuresBySourceId = ["beta": "Beta checkout is locked"]
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+
+        var failingState = try fixture.readState()
+        failingState.inspectFailuresRemainingBySourceId = ["alpha": 1]
+        try fixture.writeState(failingState)
+
+        await model.updateAllGroupsFromHome()
+
+        XCTAssertEqual(model.toast?.style, .neutral)
+        XCTAssertTrue(model.toast?.message.contains("1 groups updated, 1 failed") == true)
+        XCTAssertTrue(model.toast?.message.contains("Beta checkout is locked") == true)
+        XCTAssertTrue(model.toast?.message.contains("details may be stale") == true)
+        XCTAssertFalse(
+            fixture.loggedRequests().contains {
+                $0.command == "inspect" && $0.payload?["sourceId"]?.value as? String == "beta"
+            }
+        )
+    }
+
+    func testBulkUpdateUsesCompletionTimeRouteEligibility() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        state.updateDelayMilliseconds = 250
+        var updatedAlpha = try XCTUnwrap(state.sources["alpha"])
+        updatedAlpha.leafs.append(
+            TestFixture.LeafState(
+                id: "alpha-c",
+                linkName: "audit",
+                name: "audit",
+                description: "Fresh audit skill.",
+                metadataWarnings: []
+            )
+        )
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: true,
+                    addedLeafIds: ["alpha-c"],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: updatedAlpha
+            )
+        ]
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+
+        let update = Task { @MainActor in await model.updateAllGroupsFromHome() }
+        try await fixture.waitForLoggedRequest(command: "update")
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        await model.selectSource("alpha")
+        XCTAssertFalse(model.detailSnapshot(for: "alpha")?.skills.contains(where: { $0.id == "alpha-c" }) == true)
+
+        await update.value
+
+        XCTAssertEqual(appState.view.currentRoute, .detail(sourceId: "alpha"))
+        XCTAssertTrue(model.detailSnapshot(for: "alpha")?.skills.contains(where: { $0.id == "alpha-c" }) == true)
+    }
+
+    func testLeavingDetailBeforeUpdateCompletionDoesNotRestoreOrInspectIt() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        state.updateDelayMilliseconds = 250
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: true,
+                    addedLeafIds: [],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: state.sources["alpha"]
+            )
+        ]
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+
+        let update = Task { @MainActor in await model.updateSource("alpha") }
+        try await fixture.waitForLoggedRequest(command: "update")
+        appState.view.currentRoute = .home
+        await update.value
+
+        XCTAssertEqual(appState.view.currentRoute, .home)
+        XCTAssertEqual(
+            fixture.loggedRequests().filter {
+                $0.command == "inspect" && $0.payload?["sourceId"]?.value as? String == "alpha"
+            }.count,
+            1
+        )
+    }
+
+    func testSwitchingGroupsBeforeUpdateCompletionDoesNotRefreshPreviousDetail() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        state.updateDelayMilliseconds = 250
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: false,
+                    addedLeafIds: [],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: nil
+            )
+        ]
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+
+        let update = Task { @MainActor in await model.updateSource("alpha") }
+        try await fixture.waitForLoggedRequest(command: "update")
+        appState.view.currentRoute = .detail(sourceId: "beta")
+        await model.selectSource("beta")
+        await update.value
+
+        XCTAssertEqual(appState.view.currentRoute, .detail(sourceId: "beta"))
+        XCTAssertEqual(
+            fixture.loggedRequests().filter {
+                $0.command == "inspect" && $0.payload?["sourceId"]?.value as? String == "alpha"
+            }.count,
+            1
+        )
+    }
+
+    func testBulkUpdateWithoutExplicitCommittedIdsDoesNotRefreshActiveDetail() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        state.omitsUpdateItems = true
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+
+        await model.updateAllGroupsFromHome()
+
+        XCTAssertEqual(
+            fixture.loggedRequests().filter {
+                $0.command == "inspect" && $0.payload?["sourceId"]?.value as? String == "alpha"
+            }.count,
+            1
+        )
+    }
+
+    func testLeavingDuringPostUpdateInspectKeepsOrdinaryOutcomeAndRetriesOnReentry() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: false,
+                    addedLeafIds: [],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: nil
+            )
+        ]
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+
+        var delayedState = try fixture.readState()
+        delayedState.inspectDelayMilliseconds = 250
+        try fixture.writeState(delayedState)
+        let update = Task { @MainActor in await model.updateSource("alpha") }
+        try await fixture.waitForLoggedRequest(command: "inspect", sourceId: "alpha", minimumCount: 2)
+        appState.view.currentRoute = .home
+        await update.value
+
+        XCTAssertEqual(model.toast?.style, .success)
+        XCTAssertFalse(model.hasFreshDetailProjection(for: "alpha"))
+
+        delayedState = try fixture.readState()
+        delayedState.inspectDelayMilliseconds = nil
+        try fixture.writeState(delayedState)
+        let detailContainer = DetailScreenContainer(
+            state: appState,
+            detailSnapshot: { [weak model] sourceId in model?.detailSnapshot(for: sourceId) },
+            shouldInspectDetail: { [weak model] sourceId in model?.shouldInspectDetail(for: sourceId) ?? false },
+            selectSource: { [weak model] sourceId in await model?.selectSource(sourceId) }
+        )
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        await detailContainer.enterDetail(sourceId: "alpha")
+
+        XCTAssertTrue(model.hasFreshDetailProjection(for: "alpha"))
+        XCTAssertEqual(
+            fixture.loggedRequests().filter {
+                $0.command == "inspect" && $0.payload?["sourceId"]?.value as? String == "alpha"
+            }.count,
+            3
+        )
+    }
+
+    func testSwitchingProjectScopeBeforeUpdateCompletionPreservesNewScope() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        state.updateDelayMilliseconds = 250
+        state.updateResponseIncludesWorkspace = true
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: true,
+                    addedLeafIds: [],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: state.sources["alpha"]
+            )
+        ]
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        appState.settings.recentProjectScopes = [
+            RecentProjectScopeItem(
+                projectId: "repo-a",
+                title: "Repo A",
+                lastActivityAt: "2026-03-30T00:00:00Z",
+                projectPath: "/Users/test/src/repo-a",
+                tools: []
+            )
+        ]
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+
+        let update = Task { @MainActor in await model.updateSource("alpha") }
+        try await fixture.waitForLoggedRequest(command: "update")
+        await model.selectProjectScope(.project("repo-a"))
+        await update.value
+
+        XCTAssertEqual(model.selectedProjectScope, .project("repo-a"))
+        XCTAssertEqual(appState.view.currentRoute, .detail(sourceId: "alpha"))
+        XCTAssertEqual(
+            fixture.loggedRequests().filter {
+                $0.command == "inspect" && $0.payload?["sourceId"]?.value as? String == "alpha"
+            }.count,
+            2
+        )
+    }
+
+    func testNoOpActiveDetailUpdateDoesNotForceAnotherEnrichmentRequest() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        state.inspectEnrichmentDelayMilliseconds = 400
+        state.sources["alpha"]?.inspectEnrichmentTotalInstalls = 987_654
+        state.sources["alpha"]?.inspectEnrichmentGroupPath = "/stale/pre-update/path"
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: false,
+                    addedLeafIds: [],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: nil
+            )
+        ]
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+        try await fixture.waitForLoggedRequest(command: "inspect-enrichment", sourceId: "alpha")
+
+        await model.updateSource("alpha")
+        try await fixture.waitForLoggedRequest(
+            command: "inspect-enrichment",
+            sourceId: "alpha",
+            model: model,
+            expectedDetailTitle: "AlphaHub",
+            expectedDownloadCount: 987_654
+        )
+
+        let detail = try XCTUnwrap(model.detailSnapshot(for: "alpha"))
+        XCTAssertTrue(model.hasFreshDetailProjection(for: "alpha"))
+        XCTAssertEqual(detail.groupStats.downloadCount, 987_654)
+        XCTAssertNotEqual(detail.groupPath, "/stale/pre-update/path")
+        XCTAssertTrue(model.hasPreparedOrScheduledDetailContent(for: "alpha"))
+        XCTAssertEqual(
+            fixture.loggedRequests().filter {
+                $0.command == "inspect-enrichment" && $0.payload?["sourceId"]?.value as? String == "alpha"
+            }.count,
+            1
+        )
+    }
+
+    func testNoOpUpdateAwayFromDetailDoesNotInspectOrPrepareDetail() async throws {
+        let fixture = try TestFixture.install()
+        var state = TestFixture.State.baseline
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: false,
+                    addedLeafIds: [],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: nil
+            )
+        ]
+        try fixture.reset(state: state)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .home
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+
+        await model.updateSource("alpha")
+
+        XCTAssertFalse(fixture.loggedRequests().contains { $0.command == "inspect" })
+        XCTAssertFalse(model.hasPreparedOrScheduledDetailContent(for: "alpha"))
+        XCTAssertEqual(appState.view.currentRoute, .home)
+    }
+
+    func testPostUpdateRejectsMissingMalformedAndMismatchedInspectPayloads() async throws {
+        for payloadMode in ["missing", "malformed", "mismatched", "incomplete"] {
+            let fixture = try TestFixture.install()
+            var state = TestFixture.State.baseline
+            state.pendingUpdatesBySourceId = [
+                "alpha": TestFixture.State.PendingUpdateState(
+                    result: TestFixture.State.UpdateResultState(
+                        changed: false,
+                        addedLeafIds: [],
+                        removedLeafIds: [],
+                        invalidatedLeafIds: []
+                    ),
+                    nextSource: nil
+                )
+            ]
+            try fixture.reset(state: state)
+
+            let appState = DesktopAppState()
+            appState.view.currentRoute = .detail(sourceId: "alpha")
+            let model = MainViewModel(bridgeClient: BridgeClient())
+            model.bindRouteState(appState)
+            await model.bootstrap()
+            await model.selectSource("alpha")
+            let lastUsableSkillIds = model.detailSnapshot(for: "alpha")?.skills.map(\.id)
+
+            var invalidState = try fixture.readState()
+            invalidState.inspectPayloadModeBySourceId = ["alpha": payloadMode]
+            try fixture.writeState(invalidState)
+
+            await model.updateSource("alpha")
+
+            XCTAssertEqual(model.toast?.style, .neutral, payloadMode)
+            XCTAssertFalse(model.hasFreshDetailProjection(for: "alpha"), payloadMode)
+            XCTAssertEqual(model.detailSnapshot(for: "alpha")?.skills.map(\.id), lastUsableSkillIds, payloadMode)
+        }
+    }
+
+    func testDeleteSourceClearsProjectionPreparedContentAndInFlightInspectGeneration() async throws {
+        let fixture = try TestFixture.install()
+        try fixture.reset(state: .baseline)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+        try await fixture.waitForDetailHydration(model, sourceId: "alpha")
+        XCTAssertTrue(model.hasPreparedOrScheduledDetailContent(for: "alpha"))
+
+        var delayedState = try fixture.readState()
+        delayedState.inspectDelayMilliseconds = 300
+        try fixture.writeState(delayedState)
+        let staleInspect = Task { @MainActor in await model.selectSource("alpha") }
+        try await fixture.waitForLoggedRequest(command: "inspect", sourceId: "alpha", minimumCount: 2)
+
+        let originalAlpha = delayedState.sources["alpha"]
+        await model.deleteSource(sourceId: "alpha")
+
+        delayedState = try fixture.readState()
+        delayedState.sources["alpha"] = originalAlpha
+        delayedState.inspectDelayMilliseconds = nil
+        try fixture.writeState(delayedState)
+        await model.refreshList()
+        await staleInspect.value
+
+        XCTAssertFalse(model.hasPreparedOrScheduledDetailContent(for: "alpha"))
+        XCTAssertTrue(model.shouldInspectDetail(for: "alpha"))
+    }
+
+    func testPostUpdateInspectSupersedesPreCommitInspectThatFinishesLater() async throws {
+        let fixture = try TestFixture.install()
+        try fixture.reset(state: .baseline)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+
+        var pendingState = try fixture.readState()
+        pendingState.inspectDelayMilliseconds = 400
+        let addedSkill = TestFixture.LeafState(
+            id: "alpha-c",
+            linkName: "audit",
+            name: "audit",
+            description: "Fresh audit skill.",
+            metadataWarnings: []
+        )
+        var updatedAlpha = try XCTUnwrap(pendingState.sources["alpha"])
+        updatedAlpha.leafs.append(addedSkill)
+        pendingState.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: true,
+                    addedLeafIds: [addedSkill.id],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: updatedAlpha
+            )
+        ]
+        try fixture.writeState(pendingState)
+        try fixture.writeSkillDocument(
+            sourceId: "alpha",
+            leafId: addedSkill.id,
+            content: "# Fresh Audit\n\nPost-update content remains authoritative."
+        )
+
+        let staleInspect = Task { @MainActor in
+            await model.selectSource("alpha")
+        }
+        try await fixture.waitForLoggedRequest(command: "inspect", sourceId: "alpha", minimumCount: 2)
+
+        pendingState.inspectDelayMilliseconds = nil
+        try fixture.writeState(pendingState)
+        await model.updateSource("alpha")
+        await staleInspect.value
+
+        XCTAssertTrue(model.detailSnapshot(for: "alpha")?.skills.contains(where: { $0.id == addedSkill.id }) == true)
+        XCTAssertEqual(
+            fixture.loggedRequests().filter {
+                $0.command == "inspect" && $0.payload?["sourceId"]?.value as? String == "alpha"
+            }.count,
+            3
+        )
+    }
+
+    func testSupersededInspectFailureIsInvisibleAfterNewerPostUpdateInspectSucceeds() async throws {
+        let fixture = try TestFixture.install()
+        try fixture.reset(state: .baseline)
+
+        let appState = DesktopAppState()
+        appState.view.currentRoute = .detail(sourceId: "alpha")
+        let model = MainViewModel(bridgeClient: BridgeClient())
+        model.bindRouteState(appState)
+        await model.bootstrap()
+        await model.selectSource("alpha")
+
+        var state = try fixture.readState()
+        state.inspectDelayMilliseconds = 300
+        state.inspectFailuresRemainingBySourceId = ["alpha": 1]
+        try fixture.writeState(state)
+        let staleInspect = Task { @MainActor in await model.selectSource("alpha") }
+        try await fixture.waitForLoggedRequest(command: "inspect", sourceId: "alpha", minimumCount: 2)
+
+        state = try fixture.readState()
+        state.inspectDelayMilliseconds = nil
+        state.pendingUpdatesBySourceId = [
+            "alpha": TestFixture.State.PendingUpdateState(
+                result: TestFixture.State.UpdateResultState(
+                    changed: false,
+                    addedLeafIds: [],
+                    removedLeafIds: [],
+                    invalidatedLeafIds: []
+                ),
+                nextSource: nil
+            )
+        ]
+        try fixture.writeState(state)
+        await model.updateSource("alpha")
+        await staleInspect.value
+
+        XCTAssertTrue(model.hasFreshDetailProjection(for: "alpha"))
+        XCTAssertEqual(model.toast?.style, .success)
+        XCTAssertEqual(model.toast?.message, "Updated 1 group.")
+    }
+
     func testUpdateAllGroupsFromHomeMarksOnlySourcesWithActualUpdateChanges() async throws {
         let fixture = try TestFixture.install()
         var state = TestFixture.State.baseline
@@ -1220,6 +1945,8 @@ final class MainViewModelSelectionTests: XCTestCase {
         try await Task.sleep(nanoseconds: 100_000_000)
 
         XCTAssertFalse(model.hasPreparedOrScheduledDetailContent(for: "alpha"))
+        try await fixture.waitForDetailHydration(model, sourceId: "alpha")
+        XCTAssertTrue(model.hasPreparedOrScheduledDetailContent(for: "alpha"))
     }
 
     func testRenameSourceKeepsDetailTitleWhenInFlightEnrichmentReturnsOldSnapshot() async throws {
@@ -1527,7 +2254,7 @@ final class MainViewModelSelectionTests: XCTestCase {
         let model = MainViewModel(bridgeClient: BridgeClient())
         await model.bootstrap()
 
-        XCTAssertFalse(model.hasInspectPayload(for: "alpha"))
+        XCTAssertFalse(model.hasFreshDetailProjection(for: "alpha"))
 
         let detail = model.detailSnapshot(for: "alpha")
 
@@ -1549,7 +2276,7 @@ final class MainViewModelSelectionTests: XCTestCase {
         await model.selectSource("alpha")
 
         let initialDetail = model.detailSnapshot(for: "alpha")
-        XCTAssertTrue(model.hasInspectPayload(for: "alpha"))
+        XCTAssertTrue(model.hasFreshDetailProjection(for: "alpha"))
         XCTAssertEqual(initialDetail?.title, "AlphaHub")
         XCTAssertEqual(initialDetail?.groupStats.starCount, 1200)
         XCTAssertNil(initialDetail?.groupStats.githubURL)
@@ -2015,6 +2742,7 @@ private struct TestFixture {
         var enrichmentSourceSnapshotTitle: String? = nil
         var sourceSnapshotSkillCount: Int? = nil
         var inspectEnrichmentTotalInstalls: Int? = nil
+        var inspectEnrichmentGroupPath: String? = nil
         var omitsInspectEnrichmentMetadata: Bool? = nil
     }
 
@@ -2037,6 +2765,12 @@ private struct TestFixture {
         var listDelayMilliseconds: Int? = nil
         var inspectDelayMilliseconds: Int? = nil
         var inspectEnrichmentDelayMilliseconds: Int? = nil
+        var updateDelayMilliseconds: Int? = nil
+        var updateResponseIncludesWorkspace = false
+        var omitsUpdateItems = false
+        var updateFailuresBySourceId: [String: String] = [:]
+        var inspectFailuresRemainingBySourceId: [String: Int] = [:]
+        var inspectPayloadModeBySourceId: [String: String] = [:]
         var pendingUpdatesBySourceId: [String: PendingUpdateState] = [:]
 
         static let baseline = State(
@@ -2221,12 +2955,16 @@ private struct TestFixture {
     }
 
     func reset(state: State) throws {
+        try writeState(state)
+        try Data("".utf8).write(to: logURL)
+        try writeSkillDocuments(state: state)
+    }
+
+    func writeState(_ state: State) throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(state)
         try data.write(to: stateURL)
-        try Data("".utf8).write(to: logURL)
-        try writeSkillDocuments(state: state)
     }
 
     func readState() throws -> State {
@@ -2333,11 +3071,12 @@ private struct TestFixture {
     }
 
     func writeSkillDocument(sourceId: String, leafId: String, content: String) throws {
-        let url = rootURL
+        let directoryURL = rootURL
             .appendingPathComponent("docs", isDirectory: true)
             .appendingPathComponent(sourceId, isDirectory: true)
             .appendingPathComponent(leafId, isDirectory: true)
-            .appendingPathComponent("SKILL.md")
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let url = directoryURL.appendingPathComponent("SKILL.md")
         try content.write(to: url, atomically: true, encoding: .utf8)
     }
 
@@ -2693,9 +3432,45 @@ private struct TestFixture {
         return;
       }
 
+      if (request.command === 'uninstall') {
+        const sourceIds = Array.isArray(request.payload?.sourceIds) ? request.payload.sourceIds : [];
+        for (const sourceId of sourceIds) {
+          delete state.sources[sourceId];
+        }
+        writeState(state);
+        process.stdout.write(JSON.stringify(responseFor(request, true, { removedSourceIds: sourceIds }, [], [])));
+        return;
+      }
+
       if (request.command === 'inspect') {
         const sourceId = request.payload && request.payload.sourceId;
-        const response = JSON.stringify(responseFor(request, true, buildInspectPayload(state, sourceId), [], []));
+        const failuresRemaining = state.inspectFailuresRemainingBySourceId?.[sourceId] || 0;
+        if (failuresRemaining > 0) {
+          state.inspectFailuresRemainingBySourceId[sourceId] = failuresRemaining - 1;
+          writeState(state);
+          const response = JSON.stringify(responseFor(request, false, null, [], [{
+            code: 'inspect_failed',
+            message: 'Detail inspect failed.'
+          }]));
+          if (state.inspectDelayMilliseconds > 0) {
+            setTimeout(() => process.stdout.write(response), state.inspectDelayMilliseconds);
+          } else {
+            process.stdout.write(response);
+          }
+          return;
+        }
+        const payloadMode = state.inspectPayloadModeBySourceId?.[sourceId];
+        let inspectPayload = buildInspectPayload(state, sourceId);
+        if (payloadMode === 'missing') {
+          inspectPayload = null;
+        } else if (payloadMode === 'malformed') {
+          inspectPayload = ['not-a-detail-payload'];
+        } else if (payloadMode === 'mismatched') {
+          inspectPayload.source.id = `${sourceId}-other`;
+        } else if (payloadMode === 'incomplete') {
+          delete inspectPayload.binding;
+        }
+        const response = JSON.stringify(responseFor(request, true, inspectPayload, [], []));
         if (state.inspectDelayMilliseconds > 0) {
           setTimeout(() => process.stdout.write(response), state.inspectDelayMilliseconds);
         } else {
@@ -2749,6 +3524,7 @@ private struct TestFixture {
         })();
         const response = JSON.stringify(responseFor(request, true, {
           sourceMetadata,
+          ...(source.inspectEnrichmentGroupPath ? { groupPath: source.inspectEnrichmentGroupPath } : {}),
           ...(source.enrichmentSourceSnapshotTitle ? {
             sourceSnapshot: buildSourceSnapshot(source, source.enrichmentSourceSnapshotTitle)
           } : {})
@@ -2832,10 +3608,17 @@ private struct TestFixture {
       }
 
       if (request.command === 'update') {
+        if (state.updateDelayMilliseconds > 0) {
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, state.updateDelayMilliseconds);
+        }
         const requestedSourceIds = Array.isArray(request.payload?.sourceIds) && request.payload.sourceIds.length > 0
           ? request.payload.sourceIds
           : Object.keys(state.sources || {});
-        const updated = requestedSourceIds.map((sourceId) => {
+        const failed = requestedSourceIds.flatMap((sourceId) => {
+          const message = state.updateFailuresBySourceId?.[sourceId];
+          return message ? [{ sourceId, code: 'SOURCE_UPDATE_FAILED', message }] : [];
+        });
+        const updated = requestedSourceIds.filter((sourceId) => !state.updateFailuresBySourceId?.[sourceId]).map((sourceId) => {
           const pendingUpdate = state.pendingUpdatesBySourceId?.[sourceId];
           if (pendingUpdate?.nextSource) {
             state.sources[sourceId] = pendingUpdate.nextSource;
@@ -2861,9 +3644,18 @@ private struct TestFixture {
           };
         });
         writeState(state);
-        process.stdout.write(JSON.stringify(responseFor(request, true, {
-          updated
-        }, [], [])));
+        const response = JSON.stringify(responseFor(request, true, {
+          ...(state.omitsUpdateItems ? {} : { updated, failed }),
+          ...(state.updateResponseIncludesWorkspace ? {
+            workspace: {
+              summaries: buildSummaries(state),
+              pinnedSourceIds: state.pinnedSourceIds || [],
+              availableTargets: state.availableTargets || [],
+              groupCardEnrichmentBySourceId: buildGroupCardEnrichment(state)
+            }
+          } : {})
+        }, [], []));
+        process.stdout.write(response);
         return;
       }
 

--- a/apps/desktop-mac/Tests/SkillFlowDesktopTests/WorkflowCoverageTests.swift
+++ b/apps/desktop-mac/Tests/SkillFlowDesktopTests/WorkflowCoverageTests.swift
@@ -229,7 +229,7 @@ final class WorkflowCoverageTests: XCTestCase {
         await waitForCondition(timeoutNanoseconds: 1_500_000_000) {
             self.inspectRequestCount(in: fixture, sourceId: "alpha") == 1
                 && self.inspectEnrichmentRequestCount(in: fixture, sourceId: "alpha") == 1
-                && container.mainViewModel.hasInspectPayload(for: "alpha")
+                && container.mainViewModel.hasFreshDetailProjection(for: "alpha")
         }
 
         try await Task.sleep(nanoseconds: 150_000_000)
@@ -1383,10 +1383,29 @@ private struct TestFixture {
         const sourceId = request.payload && request.payload.sourceId;
         const source = (state.sources || {})[sourceId] || {};
         process.stdout.write(JSON.stringify(responseFor(request, true, {
-          sourceId,
-          leafIds: source.leafIds || [],
-          selectedLeafIds: source.selectedLeafIds || [],
-          enabledTargets: source.enabledTargets || []
+          summary: buildSummaries(state).find((item) => item.source.id === sourceId),
+          source: {
+            id: sourceId,
+            kind: source.kind || 'git',
+            displayName: source.displayName || sourceId,
+            originalDisplayName: source.displayName || sourceId,
+            locator: source.locator || sourceId
+          },
+          leafs: (source.leafIds || []).map((leafId) => ({
+            id: leafId,
+            sourceId,
+            title: leafId,
+            name: leafId,
+            linkName: leafId,
+            description: ''
+          })),
+          binding: {
+            selectedLeafIds: source.selectedLeafIds || [],
+            targets: Object.fromEntries((source.enabledTargets || []).map((target) => [target, {
+              enabled: true,
+              leafIds: source.selectedLeafIds || []
+            }]))
+          }
         }, [], [])));
         return;
       }

--- a/docs/superpowers/specs/2026-09-01-desktop-active-detail-freshness-cleanup.md
+++ b/docs/superpowers/specs/2026-09-01-desktop-active-detail-freshness-cleanup.md
@@ -1,0 +1,134 @@
+# Desktop Active Detail Freshness Cleanup
+
+## Problem Statement
+
+用户在 macOS 桌面端打开 Skill Group 详情并执行 Update 后，源 checkout 可能已经成功提交到新版本，但当前详情 projection 仍继续展示更新前的 inspect payload 或已经准备好的文档内容。新增、删除或修改的 Skill 因而可能没有及时反映到完整文档、内容统计、目录树和当前选择中，用户无法确认屏幕内容是否与刚完成的更新一致。
+
+问题的根因不是源更新失败，而是 durable mutation commit 与 detail projection 之间没有明确的新版本边界：普通详情检查可能复用更新前的 in-flight inspect，旧 inspect 或旧文档准备又可能在更新完成后迟到并覆盖新结果。当前 PR 虽然覆盖了这些竞争，但把 freshness、重试、同步策略和 route/scope 资格拆散为多组布尔参数、重复 payload cache 与旁路 retry set，同时混入最近更新徽标和无关测试维护，扩大了变更范围和理解成本。
+
+在继续开发前，需要先把当前分支恢复为只包含本工作包所需证据的聚焦基线，再以单一 detail projection 状态和单一提交后刷新流程重新实现相同行为。
+
+## Solution
+
+用户完成单个或批量 Update 后，桌面端只对更新完成时仍处于当前 route、仍是受影响 Skill Group、且 project scope 未改变的详情启动一次提交后的全新 inspect。新 inspect 必须拥有高于更新前请求的 generation，旧请求和旧文档准备不得回写。新 payload 被接受后，桌面端撤销旧的已准备内容，并重新生成完整 Skill 文档、内容统计和目录树。
+
+详情 projection 只保留一个权威状态 owner。该状态同时表达最后可用 payload 与 freshness；刷新失败时保留最后可用 payload，并把状态显式标记为需要重新检查，而不是把“存在但已过期”伪装成“没有 payload”。用户重新进入详情时，桌面端根据 freshness 自动重试。
+
+单个 Update 与 Bulk Update 共享同一个提交后详情刷新流程。调用方只提供更新范围与 operation scope，并消费明确的刷新 outcome，不再组装多组布尔策略。Update 已提交但详情刷新失败时，不回滚 mutation、不显示普通成功提示，只显示一次明确警告。
+
+Bulk Update 只允许已经成功到达 mutation commit 的 Skill Group 进入提交后详情刷新。mutation partial failure 与 detail refresh failure 是两个独立事实；两者同时发生时，用户必须在同一个明确结果中同时看到 mutation 失败与详情仍旧的风险，任一事实都不能覆盖另一个。
+
+远程 enrichment 不因 Update 被强制重新获取，但它与 inspect projection 具有明确的字段所有权和接受代次。更新前启动的 enrichment 不能覆盖新 inspect 所拥有的 source、summary、leaf、路径或本地内容事实，也不能重新启动旧版本的文档准备。
+
+开始实现前，先从最终 diff 中移除与详情 freshness 无关的测试维护、最近更新徽标 generation 和固定 sleep 放宽，确认工作区与结构索引干净后再建立失败测试。
+
+## User Stories
+
+1. As a desktop user, I want the open Skill Group detail to reflect the source version that just finished updating, so that I can trust the content I am reading.
+2. As a desktop user, I want a newly added Skill to appear immediately after Update, so that I do not need to leave and reopen the group.
+3. As a desktop user, I want an updated Skill document to show its complete local content, so that its description is not mistaken for the full document.
+4. As a desktop user, I want content statistics to be recomputed from the accepted source version, so that displayed counts match the current document.
+5. As a desktop user, I want the detail file tree to be rebuilt from the accepted source version, so that newly added or removed files are represented correctly.
+6. As a desktop user, I want a no-op Update started from the active detail to perform a fresh inspect, so that local drift or previously stale presentation state can be corrected.
+7. As a desktop user, I want a no-op Update started away from the detail page to avoid preparing unrelated detail content, so that background work remains bounded.
+8. As a desktop user, I want Bulk Update to refresh only a currently open group that belongs to the submitted update range, so that unrelated details are not inspected.
+9. As a desktop user, I want returning Home before Update completes to remain on Home, so that completion does not reopen an old detail route.
+10. As a desktop user, I want switching to another Skill Group before Update completes to keep the new group selected, so that completion does not steal navigation.
+11. As a desktop user, I want switching project scope before Update completes to preserve the new scope, so that an old operation cannot project data into the current workspace.
+12. As a desktop user, I want an inspect started before Update to be ignored if it completes after the post-update inspect, so that old payload cannot overwrite current content.
+13. As a desktop user, I want document preparation started before Update to be ignored if it completes after the new detail version, so that stale prepared content cannot return.
+14. As a desktop user, I want a committed Update to remain committed when the follow-up detail refresh fails, so that a presentation failure does not undo durable source work.
+15. As a desktop user, I want one clear warning when the follow-up detail refresh fails, so that I understand the source is updated but the visible detail may be stale.
+16. As a desktop user, I want the last usable detail to remain visible after a refresh failure, so that the page does not collapse into an unnecessary empty state.
+17. As a desktop user, I want reopening a stale detail to retry automatically, so that recovery does not require another source Update.
+18. As a desktop user, I want a removed selected Skill to fall back to the first remaining Skill, so that the detail does not retain a ghost selection.
+19. As a desktop user, I want a group with no remaining Skills to return to its overview, so that all selection and tree state remain valid.
+20. As a maintainer, I want one authoritative detail projection state per project scope and source, so that payload and freshness cannot diverge across modules.
+21. As a maintainer, I want single and bulk updates to use the same post-commit refresh flow, so that failure and route behavior cannot drift.
+22. As a maintainer, I want request generation and stale-result rejection hidden behind the inspect interface, so that callers do not coordinate token maps themselves.
+23. As a maintainer, I want explicit refresh outcomes instead of boolean policy combinations, so that each caller handles only observable results.
+24. As a maintainer, I want tests to observe behavior through the update and detail interfaces, so that internal refactoring does not require rewriting the suite.
+25. As a maintainer, I want unrelated test maintenance removed before implementation begins, so that the final diff communicates one coherent change.
+26. As a desktop user, I want a failed superseded inspect to remain invisible after a newer inspect succeeds, so that a late error cannot replace a valid update result.
+27. As a desktop user, I want Bulk Update to refresh only groups that actually reached their mutation commit, so that failed source updates are not presented as refreshed.
+28. As a desktop user, I want Bulk mutation failures and detail refresh failures to remain simultaneously visible, so that one warning cannot hide another failure.
+29. As a desktop user, I want a malformed successful inspect response to be treated as a detail refresh failure, so that stale content is never labelled fresh without a usable payload.
+30. As a desktop user, I want re-entering a stale detail route to trigger the retry automatically, so that the recovery behavior is proven at the real screen-entry lifecycle.
+31. As a desktop user, I want an enrichment request started before Update to remain metadata-only when it finishes later, so that it cannot restore old source content.
+32. As a maintainer, I want source deletion to clear all newly owned projection, freshness, request-generation, and prepared-content state, so that a reused source identifier cannot inherit stale update state.
+
+## Implementation Decisions
+
+- The work begins with a cleanup phase. The final diff must remove unrelated luminance type-inference maintenance, generic async assertion concurrency maintenance, bridge timeout relaxation, and tag-order fixture maintenance. Those changes may be preserved only in a separate work item with their own evidence.
+- Recently Updated indicator timing, registration ordering, generation tokens, pruning races, and fixed-sleep test relaxations are outside this work package. Their current branch changes and associated claims are removed before implementation. If the indicator still has a reproducible race, it receives a separate spec and regression test.
+- Current cleanup evidence identifies three wholly unrelated test-maintenance commits and four marker-only or marker-stability commits. One additional mixed commit changes both marker registration timing and Update coordination, so cleanup is performed by behavior and final diff rather than by blindly reverting every commit.
+- The current PR head is retained as a recoverable evidence reference. After the spec is committed, the feature history is rebuilt from the current `origin/main` baseline; the `main` branch itself is neither switched nor modified. This is safer than stacking reverts across the interdependent current commits.
+- The cleanup phase is complete only when the spec is tracked, the worktree contains no uncommitted files, the branch diff contains only active-detail-freshness scope, diff whitespace checks pass, and the structural index reports current source state.
+- Detail projection state has one authoritative owner in the presentation layer. Source inspection orchestration owns in-flight requests and generation comparison, but does not retain a second payload cache.
+- Each scoped detail projection stores the last usable payload and an explicit freshness state. Freshness distinguishes at least absent, fresh, and refresh-required states.
+- Detail entry decides whether an inspect is needed from explicit freshness and in-flight state. A cached but refresh-required payload remains renderable while still causing re-entry to retry.
+- Normal navigation inspect may share an existing request for the same scoped source. Post-update inspect always starts a new generation and cannot reuse a request that began before the mutation commit.
+- Only the latest inspect generation for a scoped source may update the detail projection. Completion of an older generation is a no-op whether it succeeds or fails; it does not throw into presentation handling and does not mutate toast, warnings, freshness, selection, payload, or prepared content.
+- Single Update and Bulk Update call one purpose-specific post-commit detail refresh module. Its interface accepts the affected source identifiers and captured operation scope, performs completion-time route/source/scope eligibility checks, and returns a named outcome.
+- The mutation result supplies the identifiers that successfully reached commit, including successful no-op updates. A source reported as failed is never eligible for post-commit detail refresh even if it was originally requested.
+- The refresh outcome distinguishes not-applicable, refreshed, and refresh-failed behavior. Ineligibility before inspect and route/source/scope changes while inspect is running both produce not-applicable. Not-applicable preserves the ordinary mutation outcome; only a still-eligible inspect failure produces refresh-failed.
+- Bulk mutation outcome remains independent from detail refresh outcome. If mutation partial failure and refresh failure both occur, one combined localized warning preserves the partial mutation summary, first actionable mutation failure, and stale-detail recovery instruction.
+- The caller does not receive flags for selection mutation, forced inspection, scope preservation, or failure presentation.
+- Mutation workspace synchronization must not overwrite the user's current route or project scope. Update-specific synchronization expresses this invariant through a named interface rather than a Boolean option.
+- A successful post-update inspect atomically replaces the scoped payload, marks it fresh, invalidates prepared detail content for the accepted version, and schedules new preparation only when that detail is still active.
+- A bridge response is accepted as a successful inspect only when it is successful and contains a valid detail payload for the requested scoped source. Missing, malformed, or mismatched payload is refresh-failed for a post-update refresh and an ordinary load failure for first entry.
+- A failed post-update inspect leaves the last usable payload intact, marks the scoped projection refresh-required, suppresses the ordinary update-success presentation, and emits one localized warning. It does not roll back the committed mutation.
+- Enrichment has its own generation and metadata-only ownership. A pre-commit enrichment result may be retained without a new network request only when its source identity still matches; its merge cannot replace inspect-owned source, summary, leaf, path, revision, document, statistics, or tree facts. A superseded or identity-mismatched enrichment completion is a no-op.
+- A successful later inspect clears refresh-required state.
+- The presentation owner exposes one source-removal cleanup entry point. It removes scoped projection and freshness entries, asks inspection orchestration to cancel and invalidate all generations for the source, and invalidates prepared detail content. Existing app-lifetime selection/document stores are not rearchitected by this work; accepted detail reconciliation must still prevent ghost selections when the same identifier is introduced again.
+- Detail selection reconciliation runs when the accepted detail version changes. A missing selected Skill falls back to the first remaining Skill; an empty Skill list clears pending/current/tree selection and returns to the group overview.
+- Detail version observation may expose an existing revision value to the view, but revision exists only to identify accepted projection changes. It does not become a second freshness source.
+- Detail screen entry delegates its lifecycle work to one testable container entry point. That entry point decides from freshness and in-flight state whether to inspect, performs the inspect, and applies accepted selection reconciliation. SwiftUI task wiring remains thin.
+- No alias, shim, compatibility branch, new persistent setting, new bridge command, or new external protocol is introduced.
+- Existing Group Operation Queue serialization and quit recovery semantics remain unchanged. The post-commit detail refresh occurs after a source transaction reaches its existing commit point.
+- The final implementation removes replaced helpers, overloads, Boolean policy parameters, retry sets, duplicate caches, obsolete tests, and obsolete PR claims in the same change; no intermediate compatibility path remains. The three-language detail-refresh warning remains part of the required behavior.
+
+## Testing Decisions
+
+- The primary test seam is the desktop view model's existing Update and Bulk Update behavior with the local bridge fixture. Tests invoke the same update entry points as the UI and observe route, scope, visible detail projection, localized presentation, and logged bridge requests.
+- Automatic retry on route re-entry is tested through the detail container's real entry operation used by the screen lifecycle. The test does not manually call the predicate and then manually invoke source selection as a substitute for entry.
+- Tests assert external behavior rather than token values, cache dictionaries, private retry sets, or helper call order. Generation is verified by completing an older inspect after a newer one and asserting that visible detail remains current.
+- The primary seam covers active-detail single Update, active-detail no-op Update, Home no-op Update, Bulk Update eligibility, leaving detail, switching groups, switching project scope, stale inspect completion, stale document preparation, committed-update refresh failure, and automatic retry on re-entry.
+- Stale inspect coverage includes both late success and late failure after a newer accepted inspect. Both outcomes must leave the newer detail, toast, warnings, freshness, and preparation unchanged.
+- Enrichment coverage completes a pre-commit enrichment after the post-update inspect and verifies that only enrichment-owned metadata may change; inspect-owned content and warmup generation remain current without forcing another remote request.
+- The existing pure detail-route selection seam is retained only for selected-Skill deletion and empty-group fallback, because those are deterministic presentation-state rules that do not require bridge execution.
+- Failure-first evidence is required before implementation for the stale-detail root cause, stale inspect overwrite, refresh-required retry, and Bulk refresh-failure presentation.
+- Tests use request gates, continuations, logged-request milestones, or bounded eventually assertions to control concurrency. New fixed sleeps are not accepted as the sole synchronization mechanism.
+- The suite verifies that a cached refresh-required detail remains renderable while the detail entry still requests a new inspect.
+- The suite verifies that source deletion clears freshness and retry behavior before the same source identifier can be reintroduced.
+- Source deletion coverage also verifies cancellation/no-op behavior for an in-flight inspect and invalidation of prepared detail content. Existing selection state is reconciled against the newly accepted detail rather than trusted by identifier alone.
+- The suite verifies that an inactive or out-of-scope detail never receives post-update payload, selection, warning, or warmup changes.
+- The suite verifies both the mutation response path that contains a workspace projection and the fallback path that requires list/doctor synchronization.
+- At least one core active-detail refresh success case uses the mutation workspace path, and at least one uses list/doctor fallback; failure behavior is not inferred from only one synchronization path.
+- Bulk coverage includes a requested active source whose mutation fails, plus a partial mutation failure combined with a detail refresh failure. It verifies that failed sources are not inspected and neither failure is hidden.
+- Inspect contract coverage treats missing, malformed, or source-mismatched successful payloads as non-acceptable.
+- Existing detail document hydration and render-cache tests remain the prior art for complete document, statistics, and file-tree rebuilding. Existing route and project-scope tests remain prior art for navigation ownership.
+- Validation runs the smallest affected desktop tests first, then the complete desktop test suite, then the repository build and test entry points. A platform-dependent skip is recorded rather than described as a pass.
+- Final installed-app visual verification checks that Update immediately refreshes full content, statistics, and file tree without reopening the group and without error 599.
+
+## Out of Scope
+
+- Recently Updated indicator duration, generation, pruning, and cross-scope marker behavior.
+- Generic macOS CI timing stabilization, compiler type-inference cleanup, Sendable cleanup, tag ordering, and bridge timeout tuning.
+- CLI or TUI behavior changes.
+- Bridge request or response schema changes.
+- Group Operation Queue ordering, preparation concurrency, cancellation, or durable recovery changes.
+- Forcing a new remote enrichment request solely because a source Update completed. Enrichment ownership and stale-result isolation remain in scope.
+- A broad decomposition of the entire desktop view model beyond the detail projection and post-update refresh seam.
+- New user settings, persistent retry queues, background job panels, manual Cancel actions, or cross-launch detail refresh jobs.
+- Release packaging, publication, merge to `main`, or modification of unrelated documentation.
+
+## Further Notes
+
+- The authoritative terminology is mutation commit, detail projection, scoped source, inspect generation, prepared detail content, and refresh-required freshness.
+- The current branch is evidence for the required behavior but is not the desired implementation shape. Cleanup removes unrelated and replaced logic before new implementation begins rather than layering another refactor on top.
+- Cleanup restores `origin/main` Recently Updated behavior exactly; it does not delete the existing indicator feature. The removed scope is only the current branch's marker registration relocation, generation tokens, timing relaxations, related tests, and PR claims.
+- Cleanup removes the current branch's unrelated luminance, async assertion, bridge timeout, and tag-order changes. Existing baseline tests remain untouched.
+- Safe execution order is: preserve the current PR reference; commit and record this spec commit; rebuild the feature branch from `origin/main`; explicitly reapply the recorded spec commit to the rebuilt history; restore failure-first behavior tests; implement the single projection state and post-commit refresh flow; delete replaced state and helpers; run focused and full validation; then rewrite PR claims and evidence.
+- The repository currently lacks the configured Matt Pocock Issue Tracker and triage vocabulary files. Publishing this spec and applying `ready-for-agent` remains pending until `setup-matt-pocock-skills` restores that configuration.
+- The existing PR's installed-app visual acceptance remains incomplete and must not be inferred from automated tests.

--- a/docs/superpowers/specs/README.md
+++ b/docs/superpowers/specs/README.md
@@ -1,5 +1,7 @@
 # Specs 状态
 
-当前没有活跃需求规格。
+当前活跃需求规格：
+
+- [Desktop Active Detail Freshness Cleanup](2026-09-01-desktop-active-detail-freshness-cleanup.md)
 
 已完成、废弃或被替代的历史规格位于 `../../archives/specs/`。新需求启动时，可在本目录新增对应规格；完成或废弃后再归档。


### PR DESCRIPTION
## 问题

用户在 Skill Group 详情页执行 Update 后，源更新虽然已经提交，但当前详情仍可能继续展示更新前的 payload。新增或删除的 Skill、完整文档、字数统计和文件树只有离开并重新进入详情页后才会更新。

根因是详情 payload、请求代次和页面进入重试分别由多套状态协调，提交前启动的 inspect 或 enrichment 也可能晚于新结果完成。

## 最终行为

- 单 Group Update 和 Bulk Update 共用同一条 post-commit detail refresh 流程。
- 仅当更新完成时当前 route、source 和 project scope 仍匹配，才刷新活动详情。
- Bulk Update 只刷新 mutation 响应中明确列为 committed 的 source；失败或无法确认的 source 不触发 inspect。
- post-commit inspect 必须启动新 generation；旧成功和旧失败 completion 均为无副作用 no-op。
- inspect 响应只有在 source、summary、binding 和 leafs 合同完整且 source identity 匹配时才会被接受。
- 刷新成功后原子替换详情 projection，并重新准备完整文档、统计和文件树。
- 刷新失败时保留最后可用内容、标记 refresh-required，并显示本地化警告；重新进入详情自动重试。
- 更新删除当前 Skill 时协调 selection；没有剩余 Skill 时回到 Group 概览。
- enrichment 仅拥有 metadata/snapshot 字段，不能覆盖 inspect 提供的 source、Skill、路径、文档、统计事实或文件树。
- source 删除成功后立即清理 projection、freshness、inspect generation、enrichment 和 prepared content。

## 设计取舍

- presentation layer 是详情 projection 的唯一 payload owner。
- request orchestration 只负责 in-flight request 和 generation 比较，不保留第二份 payload cache。
- 不新增 bridge 命令、持久设置、兼容层或 Boolean policy 参数。
- Recently Updated marker 的时序与稳定性不属于本 PR，重建历史时已移除相关补丁和测试维护提交。

## 验证

- [x] 相关桌面测试：156/156
- [x] 完整 `swift test`：631/631
- [x] `npm run build`
- [x] `npm test`（CLI 206/206）
- [x] 三语言 `Localizable.strings` 通过 `plutil -lint`
- [x] `git diff --check`
- [x] CodeGraph 索引同步且状态为最新
- [x] Standards/Spec 双轴复核均为 ✅OK
- [x] 隔离安装版人工目视验收：Update 后新增 Skill、完整内容、统计和文件树立即刷新，且未出现错误 599

## Spec

`docs/superpowers/specs/2026-09-01-desktop-active-detail-freshness-cleanup.md`